### PR TITLE
Update makefile and environment variables

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -16,8 +16,8 @@
 # under the License.
 
 [target.aarch64-unknown-optee-trustzone]
-linker = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-ld"
-ar = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc-ar"
+linker = "aarch64-linux-gnu-ld"
+ar = "aarch64-linux-gnu-gcc-ar"
 rustflags = [
     "-C", "link-arg=-e__ta_entry",
     "-C", "link-arg=-nostdlib",
@@ -29,12 +29,12 @@ rustflags = [
 ]
 
 [target.aarch64-unknown-linux-gnu]
-linker = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc"
-ar = "optee/toolchains/aarch64/bin/aarch64-linux-gnu-gcc-ar"
+linker = "aarch64-linux-gnu-gcc"
+ar = "aarch64-linux-gnu-gcc-ar"
 
 [target.arm-unknown-optee-trustzone]
-linker = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd"
-ar = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-ld.bfd"
+ar = "arm-linux-gnueabihf-ar"
 rustflags = [
     "-C", "link-arg=-e__ta_entry",
     "-C", "link-arg=-nostdlib",
@@ -45,5 +45,5 @@ rustflags = [
 ]
 
 [target.arm-unknown-linux-gnueabihf]
-linker = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc"
-ar = "optee/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc-ar"
+linker = "arm-linux-gnueabihf-gcc"
+ar = "arm-linux-gnueabihf-gcc-ar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
           ln -sf /root/.cargo ~/.cargo
       - name: Building
         run: |
-          make optee &&
           source environment &&
+          make optee &&
           . ~/.cargo/env &&
           rustup default nightly-2019-07-08 &&
           make examples
@@ -60,8 +60,8 @@ jobs:
           ln -sf /root/.cargo ~/.cargo
       - name: Building
         run: |
-          make optee &&
           source environment &&
+          make optee &&
           . ~/.cargo/env &&
           rustup default nightly-2019-07-08 &&
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OPTEE_PATH        ?= $(CURDIR)/optee
+OPTEE_PATH        ?= $(OPTEE_DIR)
 OPTEE_BUILD_PATH  ?= $(OPTEE_PATH)/build
 OPTEE_OS_PATH     ?= $(OPTEE_PATH)/optee_os
 OPTEE_CLIENT_PATH ?= $(OPTEE_PATH)/optee_client
@@ -60,6 +60,9 @@ examples-install: $(EXAMPLES_INSTALL)
 $(EXAMPLES_INSTALL):
 	install -D $(@:%-install=%)/host/target/$(HOST_TARGET)/release/$(@:examples/%-install=%) -t out/host/
 	install -D $(@:%-install=%)/ta/target/$(TA_TARGET)/release/*.ta -t out/ta/
+	if [ -d "$(@:%-install=%)/plugin/target/" ]; then \
+		install -D $(@:%-install=%)/plugin/target/$(HOST_TARGET)/release/*.plugin.so -t out/plugin/; \
+	fi
 
 optee-os-clean:
 	make -C $(OPTEE_OS_PATH) O=out/arm clean

--- a/README.md
+++ b/README.md
@@ -43,18 +43,23 @@ $ rustup default 1.44.0 && cargo +1.44.0 install xargo
 $ rustup default nightly-2019-07-08
 ```
 
-Then, download ARM toolchains and build OP-TEE libraries. Note that the OP-TEE
-target is QEMUv8, and you can modify the Makefile to other targets accordingly.
-
-``` sh
-$ make optee
-```
-
 Before building examples, the environment should be properly setup.
 
 ``` sh
 $ source environment
 ```
+
+By default, the `OPTEE_DIR` is `incubator-teaclave-trustzone-sdk/optee/`.
+If you already have [OP-TEE repository](https://github.com/OP-TEE) 
+cloned, you can set OP-TEE root directory before source environment:
+
+``` sh
+$ export OPTEE_DIR=path/to/your/optee/root/directory
+$ source environment
+```
+
+Note that your OPTEE root directory should have `build/`, `optee_os/` and 
+`optee_client/` as sub-directory.
 
 By default, the target platform is `aarch64`. If you want to build for the `arm`
 target, you can setup `ARCH` before source the environment like this:
@@ -62,6 +67,13 @@ target, you can setup `ARCH` before source the environment like this:
 ```sh
 $ export ARCH=arm
 $ source environment
+```
+
+Then, download ARM toolchains and build OP-TEE libraries. Note that the OP-TEE
+target is QEMUv8, and you can modify the Makefile to other targets accordingly.
+
+``` sh
+$ make optee
 ```
 
 At last, you can get started with our examples.

--- a/environment
+++ b/environment
@@ -17,7 +17,10 @@
 
 export RUST_TARGET_PATH="$(pwd)"
 export RUST_COMPILER_RT_ROOT=$RUST_TARGET_PATH/rust/rust/src/llvm-project/compiler-rt
-export OPTEE_DIR="$(pwd)/optee"
+if [ -z "$OPTEE_DIR" ]
+then
+  export OPTEE_DIR="$(pwd)/optee"
+fi
 export OPTEE_OS_DIR="$OPTEE_DIR/optee_os"
 export OPTEE_CLIENT_DIR="$OPTEE_DIR/optee_client"
 export OPTEE_CLIENT_INCLUDE="$OPTEE_DIR/optee_client/out/export/usr/include"


### PR DESCRIPTION
- .cargo/config: remove relative path of toolchains since it has been added to `PATH` in `source environment`
- Makefile: add installation of plugins in example-install
- Makefile, environment and README.md: `OPTEE_DIR` allows setting OPTEE root path
- .github/workflows/ci.yml: fix related ci error