### PR TITLE
Fix ldelf error of arm32 ta

### DIFF
--- a/examples/acipher-rs/ta/Cargo.toml
+++ b/examples/acipher-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/acipher-rs/ta/ta_arm.lds
+++ b/examples/acipher-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/aes-rs/ta/Cargo.toml
+++ b/examples/aes-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/aes-rs/ta/ta_arm.lds
+++ b/examples/aes-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/authentication-rs/ta/Cargo.toml
+++ b/examples/authentication-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/authentication-rs/ta/ta_arm.lds
+++ b/examples/authentication-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/big_int-rs/ta/Cargo.toml
+++ b/examples/big_int-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/big_int-rs/ta/ta_arm.lds
+++ b/examples/big_int-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/diffie_hellman-rs/ta/Cargo.toml
+++ b/examples/diffie_hellman-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/diffie_hellman-rs/ta/ta_arm.lds
+++ b/examples/diffie_hellman-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/digest-rs/ta/Cargo.toml
+++ b/examples/digest-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/digest-rs/ta/ta_arm.lds
+++ b/examples/digest-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/hello_world-rs/ta/Cargo.toml
+++ b/examples/hello_world-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/hello_world-rs/ta/ta_arm.lds
+++ b/examples/hello_world-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/hotp-rs/ta/Cargo.toml
+++ b/examples/hotp-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/hotp-rs/ta/ta_arm.lds
+++ b/examples/hotp-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/message_passing_interface-rs/ta/Cargo.toml
+++ b/examples/message_passing_interface-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = false
+opt-level = 1

--- a/examples/message_passing_interface-rs/ta/ta_arm.lds
+++ b/examples/message_passing_interface-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/random-rs/ta/Cargo.toml
+++ b/examples/random-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/random-rs/ta/ta_arm.lds
+++ b/examples/random-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/secure_storage-rs/ta/Cargo.toml
+++ b/examples/secure_storage-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/secure_storage-rs/ta/ta_arm.lds
+++ b/examples/secure_storage-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/serde-rs/ta/Cargo.toml
+++ b/examples/serde-rs/ta/Cargo.toml
@@ -38,3 +38,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = false
+opt-level = 1

--- a/examples/serde-rs/ta/ta_arm.lds
+++ b/examples/serde-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/supp_plugin-rs/ta/Cargo.toml
+++ b/examples/supp_plugin-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/supp_plugin-rs/ta/ta_arm.lds
+++ b/examples/supp_plugin-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/tcp_client-rs/ta/Cargo.toml
+++ b/examples/tcp_client-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/tcp_client-rs/ta/ta_arm.lds
+++ b/examples/tcp_client-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/time-rs/ta/Cargo.toml
+++ b/examples/time-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/time-rs/ta/ta_arm.lds
+++ b/examples/time-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/examples/udp_socket-rs/ta/Cargo.toml
+++ b/examples/udp_socket-rs/ta/Cargo.toml
@@ -36,3 +36,4 @@ proto = { path = "../proto" }
 
 [profile.release]
 lto = true
+opt-level = 1

--- a/examples/udp_socket-rs/ta/ta_arm.lds
+++ b/examples/udp_socket-rs/ta/ta_arm.lds
@@ -39,7 +39,6 @@ SECTIONS {
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-	.got : { *(.got.plt) *(.got) }
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -70,6 +69,7 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
+	.got : { *(.got.plt) *(.got) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 


### PR DESCRIPTION
- `examples/*/ta/ta_arm.lds`: Add write permisson of GOT
- `examples/*/ta/Cargo.toml`: Set `opt-level=1` to compile arm32 ta of `nbuckets!=0`. In #24 we had updated `linkarg=-Os` and  `opt-level=3`(by default) which worked for arm64 ta but didn't work for arm32 ta.There should be  `linkarg=-Os` and  `opt-level=1` now.