### PR TITLE
correct toolchain PATH env

### DIFF
--- a/environment
+++ b/environment
@@ -27,14 +27,14 @@ export OPTEE_CLIENT_INCLUDE="$OPTEE_DIR/optee_client/out/export/usr/include"
 if [ "$ARCH" = "arm" ]
 then
   export ARCH="arm"
-  export PATH=$PATH:$(pwd)/optee/toolchains/aarch32/bin
+  export PATH=$PATH:$OPTEE_DIR/toolchains/aarch32/bin
   export VENDOR="qemu.mk"
   export OPTEE_OS_INCLUDE="$OPTEE_DIR/optee_os/out/arm/export-ta_arm32/include"
   export CC=$OPTEE_DIR/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc
 else
   # export ARCH="aarch64" # comment this because currently optee_os cannot be compiled in the aarch64 target
   unset ARCH
-  export PATH=$PATH:$(pwd)/optee/toolchains/aarch64/bin
+  export PATH=$PATH:$OPTEE_DIR/toolchains/aarch64/bin
   export VENDOR="qemu_v8.mk"
   export OPTEE_OS_INCLUDE="$OPTEE_DIR/optee_os/out/arm/export-ta_arm64/include"
   export CC=$OPTEE_DIR/toolchains/aarch64/bin/aarch64-linux-gnu-gcc


### PR DESCRIPTION
If `OPTEE_DIR` set by user, toolchains should be there too.