### PR TITLE
Add expect script for OP-TEE CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,34 @@ jobs:
           rustup default nightly-2019-07-08 &&
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
+  build-and-run-examples-in-OPTEE-repo:
+    runs-on: ubuntu-20.04
+    container: teaclave/teaclave-trustzone-sdk-build:0.2.1
+    steps:
+      - name: Checkout OP-TEE repository
+        run: |
+          mkdir -p ~/bin
+          curl https://storage.googleapis.com/git-repo-downloads/repo-1 > ~/bin/repo && chmod a+x ~/bin/repo
+          export PATH=~/bin:$PATH
+          mkdir optee-qemuv8 && cd optee-qemuv8 &&
+          repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml &&
+          repo sync -j4 --no-clone-bundle   
+      # This step will be removed after merging those commits to upstream:
+      - name: Switch to current commits
+        run: |
+          cd optee-qemuv8
+          (cd optee_rust && git fetch github pull/45/head && git checkout FETCH_HEAD)
+          (cd build && git fetch https://github.com/DemesneGH/build.git && git checkout FETCH_HEAD)
+      - name: Build images
+        run: |
+          cd optee-qemuv8
+          cd build &&
+          make -j2 toolchains &&
+          make OPTEE_RUST_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000
+      - name: Test Rust applications
+        run: |
+          cd optee-qemuv8
+          cd build && make CFG_TEE_CORE_LOG_LEVEL=0 check-rust
   license:
     runs-on: ubuntu-20.04
     steps:

--- a/ci/qemu-check.exp
+++ b/ci/qemu-check.exp
@@ -1,0 +1,286 @@
+#!/usr/bin/expect -f
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Expect script for OP-TEE CI Test
+#
+# This script starts QEMU, loads and boots Linux/OP-TEE, then runs
+# Rust applications in the guest. The return code is 0 for success, 
+# >0 for error.
+# It is invoked in OP-TEE/build/qemu_v8.mk and can be triggered by 
+# "$ cd OPTEE_DIR/build && make CFG_TEE_CORE_LOG_LEVEL=0 check-rust"
+
+set bios "../out/bios-qemu/bios.bin"
+set quiet 0
+set timeout 900
+
+# Parse command line
+set myargs $argv
+while {[llength $myargs]} {
+	set myargs [lassign $myargs arg]
+	switch -exact -- $arg {
+		"--bios"	{set myargs [lassign $myargs ::bios]}
+		"--timeout"	{set myargs [lassign $myargs ::timeout]}
+		"-q"		{set ::quiet 1}
+	}
+}
+
+proc info arg {
+	if {$::quiet==1} { return }
+	puts -nonewline $arg
+	flush stdout
+}
+
+# Disable echoing of guest output
+log_user 0
+# Save guest console output to a file
+log_file -a -noappend "serial0.log"
+info "Starting QEMU...\n"
+open "serial1.log" "w+"
+spawn -open [open "|tail -f serial1.log"]
+set teecore $spawn_id
+if {[string first "aarch64" $::env(QEMU)] != -1} {
+	spawn $::env(QEMU) -nographic -serial mon:stdio -serial file:serial1.log -smp $::env(QEMU_SMP) -machine virt,secure=on,gic-version=$::env(QEMU_GIC) -cpu cortex-a57 -d unimp -semihosting-config enable=on,target=native -m $::env(QEMU_MEM) -bios bl1.bin -initrd rootfs.cpio.gz -kernel Image -no-acpi -append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2"
+} else {
+	spawn $::env(QEMU) -nographic -monitor none -machine virt -machine secure=on -cpu cortex-a15 -smp $::env(QEMU_SMP) -d unimp -semihosting-config enable=on,target=native -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+}
+expect {
+	"Kernel panic" {
+		info "!!! Kernel panic\n"
+		exit 1
+	}
+	timeout {
+		info "!!! Timeout\n"
+		exit 1
+	}
+	"ogin:"
+}
+send -- "root\r\r"
+expect "# "
+info " done, guest is booted"
+info ".\n"
+
+# Test Rust applications
+info "Test Rust applications:\n"
+info "Running acipher-rs...\n"
+send -- "acipher-rs 256 teststring\r"
+expect {
+	-re "Success decrypt the above ciphertext as (\\d+) bytes plain text:" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running aes-rs...\n"
+send -- "aes-rs\r"
+expect {
+	-re "Prepare encode operation.*Encode buffer from TA.*Clear text and decoded text match" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running authentication-rs...\n"
+send -- "authentication-rs\r"
+expect {
+	-re "Clear text and decoded text match.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running big_int-rs...\n"
+send -- "big_int-rs\r"
+expect {
+	"Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running diffie_hellman-rs...\n"
+send -- "diffie_hellman-rs\r"
+expect {
+	-re "get key (\\d+) pair as public:.*private.*Derived share key as.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running digest-rs...\n"
+send -- "digest-rs message1 message2\r"
+expect {
+	-re "Get message hash as:.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running hello_world-rs...\n"
+send -- "hello_world-rs\r"
+expect {
+	-re "original value is 29.*inc value is 129.*dec value is 29.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running hotp-rs...\n"
+send -- "hotp-rs\r"
+expect {
+	-re "Get HOTP.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running message_passing_interface-rs...\n"
+send -- "message_passing_interface-rs\r"
+expect {
+	-re "Hello, World" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running random-rs...\n"
+send -- "random-rs\r"
+expect {
+	-re "Generate random UUID: \[a-z0-9]*-\[a-z0-9]*-\[a-z0-9]*-\[a-z0-9]*.*Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running secure_storage-rs...\n"
+send -- "secure_storage-rs\r"
+expect {
+	-re "We're done, close and release TEE resources" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running serde-rs...\n"
+send -- "serde-rs\r"
+expect {
+	"Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running supp_plugin-rs...\n"
+send -- "supp_plugin-rs\r"
+expect {
+	-re "invoke commmand finished" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running tcp_client-rs...\n"
+send -- "tcp_client-rs\r"
+expect {
+	"Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running time-rs...\n"
+send -- "time-rs\r"
+expect {
+	"Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
+expect "# "
+info "Running udp_socket-rs...\n"
+send -- "udp_socket-rs\r"
+expect {
+	"Success" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+info "Test Rust application finished\n"


### PR DESCRIPTION
Add `ci/qemu-check.exp` which invoked in OP-TEE/build/qemu_v8.mk
First, build Rust applications in buildroot:
```
$ (cd build && make toolchains && make OPTEE_RUST_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000)
```
Then trigger the CI for Rust applications in OP-TEE by:
```
$ (cd build && make CFG_TEE_CORE_LOG_LEVEL=0 check-rust)
```