### PR TITLE
docker: add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get update && \
     libcap-ng-dev \
     screen \
     libvdeplug-dev \
-    libsdl2-dev
+    libsdl2-dev \
+    ca-certificates
 
 RUN apt-get install -y software-properties-common && \
     add-apt-repository ppa:linuxuprising/libpng12 && \


### PR DESCRIPTION
- add `ca-certificates` in the docker image to fix the `repo` clone issue