### PR TITLE
ci.yml: remove redundant building process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,12 @@ jobs:
           mkdir optee-qemuv8 && cd optee-qemuv8 &&
           repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml &&
           repo sync -j4 --no-clone-bundle   
-      - name: Build images
+      - name: Build images and run tests
         run: |
           cd optee-qemuv8
           cd build &&
           make -j2 toolchains &&
-          make OPTEE_RUST_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000
-      - name: Test Rust applications
-        run: |
-          cd optee-qemuv8
-          cd build && make CFG_TEE_CORE_LOG_LEVEL=0 OPTEE_RUST_ENABLE=y check-rust
+          make CFG_TEE_CORE_LOG_LEVEL=0 OPTEE_RUST_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000 -j$(getconf _NPROCESSORS_ONLN) check-rust
   license:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
"make check-rust" will build images and Rust examples then run tests.
Remove the redundant "make" and add "-j" to reduce ci time.