### PR TITLE
ci: update the link for assets

### DIFF
--- a/tests/test_acipher.sh
+++ b/tests/test_acipher.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/acipher-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/acipher-rs/host/target/aarch64-unknown-linux-gnu/release/acipher-rs shared

--- a/tests/test_aes.sh
+++ b/tests/test_aes.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/aes-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/aes-rs/host/target/aarch64-unknown-linux-gnu/release/aes-rs shared

--- a/tests/test_authentication.sh
+++ b/tests/test_authentication.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/authentication-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/authentication-rs/host/target/aarch64-unknown-linux-gnu/release/authentication-rs shared

--- a/tests/test_big_int.sh
+++ b/tests/test_big_int.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/big_int-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/big_int-rs/host/target/aarch64-unknown-linux-gnu/release/big_int-rs shared

--- a/tests/test_diffie_hellman.sh
+++ b/tests/test_diffie_hellman.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/diffie_hellman-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/diffie_hellman-rs/host/target/aarch64-unknown-linux-gnu/release/diffie_hellman-rs shared

--- a/tests/test_digest.sh
+++ b/tests/test_digest.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/digest-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/digest-rs/host/target/aarch64-unknown-linux-gnu/release/digest-rs shared

--- a/tests/test_hello_world.sh
+++ b/tests/test_hello_world.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/hello_world-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/hello_world-rs/host/target/aarch64-unknown-linux-gnu/release/hello_world-rs shared

--- a/tests/test_hotp.sh
+++ b/tests/test_hotp.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/hotp-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/hotp-rs/host/target/aarch64-unknown-linux-gnu/release/hotp-rs shared

--- a/tests/test_message_passing_interface.sh
+++ b/tests/test_message_passing_interface.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/message_passing_interface-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/message_passing_interface-rs/host/target/aarch64-unknown-linux-gnu/release/message_passing_interface-rs shared

--- a/tests/test_random.sh
+++ b/tests/test_random.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/random-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/random-rs/host/target/aarch64-unknown-linux-gnu/release/random-rs shared

--- a/tests/test_secure_storage.sh
+++ b/tests/test_secure_storage.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/secure_storage-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/secure_storage-rs/host/target/aarch64-unknown-linux-gnu/release/secure_storage-rs shared

--- a/tests/test_serde.sh
+++ b/tests/test_serde.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/serde-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/serde-rs/host/target/aarch64-unknown-linux-gnu/release/serde-rs shared

--- a/tests/test_signature_verification.sh
+++ b/tests/test_signature_verification.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/signature_verification-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/signature_verification-rs/host/target/aarch64-unknown-linux-gnu/release/signature_verification-rs shared

--- a/tests/test_supp_plugin.sh
+++ b/tests/test_supp_plugin.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/supp_plugin-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/supp_plugin-rs/host/target/aarch64-unknown-linux-gnu/release/supp_plugin-rs shared

--- a/tests/test_tcp_client.sh
+++ b/tests/test_tcp_client.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/tcp_client-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/tcp_client-rs/host/target/aarch64-unknown-linux-gnu/release/tcp_client-rs shared

--- a/tests/test_time.sh
+++ b/tests/test_time.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/time-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/time-rs/host/target/aarch64-unknown-linux-gnu/release/time-rs shared

--- a/tests/test_udp_socket.sh
+++ b/tests/test_udp_socket.sh
@@ -23,7 +23,7 @@ rm -rf screenlog.0
 rm -rf optee-qemuv8-3.17.0-ubuntu-20.04
 rm -rf shared
 
-curl http://mesalock-linux.org/assets/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
+curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.17.0-ubuntu-20.04.tar.gz | tar zxv
 mkdir shared
 cp ../examples/udp_socket-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/udp_socket-rs/host/target/aarch64-unknown-linux-gnu/release/udp_socket-rs shared


### PR DESCRIPTION
Use [Apache Nightlies](https://nightlies.apache.org/authoring.html) for storing CI assets.
Directory: https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/ 