### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,13 @@ $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
 	mtools netcat python-crypto python3-crypto python-pyelftools \
 	python3-pycryptodome python3-pyelftools python-serial python3-serial \
 	rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
+```
 
+After installing dependencies or building the Docker container, fetch the source code from the official GitHub repository:
+
+``` sh
 # clone the project
-$ git clone git@github.com:apache/incubator-teaclave-trustzone-sdk.git
+$ git clone https://github.com/apache/incubator-teaclave-trustzone-sdk.git
 $ cd incubator-teaclave-trustzone-sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ $ source environment
 
 #### 4. Build Rust applications
 
+Before building built-in rust examples, you need to build OP-TEE libraries using:
+
+``` sh
+$ make optee
+```
+
 Run this command to build all Rust examples:
 
 ``` sh


### PR DESCRIPTION
- Mention making optee before examples
- Separate commands for installing dependencies and project fetching, since dockerfile hasn't include source code clone.
- Use https git url instead of ssh url.