### PR TITLE
Update readme v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
 	rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
 ```
 
-After installing dependencies or building the Docker container, fetch the source code from the official GitHub repository:
+After installing dependencies or building the Docker image, fetch the source code from the official GitHub repository:
 
 ``` sh
 # clone the project

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ (cd /project/root/dir/ && make examples-install)
 $ cp -r /project/root/dir/out/* shared_folder/
 ```
 
-Run QEMU.
+Run QEMU:
 
 ```sh
 $ (cd $OPTEE_DIR/build && make run-only QEMU_VIRTFS_ENABLE=y
@@ -144,9 +144,6 @@ process.
 The complete list of prerequisites can be found here: [OP-TEE
 Prerequisites](https://optee.readthedocs.io/en/latest/building/prerequisites.html).
 
-Alternatively, you can use a docker container built with our
-[Dockerfile](Dockerfile).
-
 ``` sh
 # install dependencies
 $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
@@ -158,6 +155,9 @@ $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
 	python3-pycryptodome python3-pyelftools python-serial python3-serial \
 	rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
 ```
+
+Alternatively, you can use a docker container built with our
+[Dockerfile](Dockerfile).
 
 After installing dependencies or building the Docker image, fetch the source code from the official GitHub repository:
 
@@ -171,7 +171,7 @@ $ cd incubator-teaclave-trustzone-sdk
 
 * By default, the `OPTEE_DIR` is
   `incubator-teaclave-trustzone-sdk/optee/`.OP-TEE submodules (`optee_os`,
-`optee_client` and` build`) will be initialized automatically in `setup.sh`. If
+`optee_client` and `build`) will be initialized automatically in `setup.sh`. If
 you already have [OP-TEE repository](https://github.com/OP-TEE)  cloned
 somewhere, you can set OP-TEE root directory:
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,13 @@ $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf \
 	mtools netcat python-crypto python3-crypto python-pyelftools \
 	python3-pycryptodome python3-pyelftools python-serial python3-serial \
 	rsync unzip uuid-dev xdg-utils xterm xz-utils zlib1g-dev
+```
 
+After installing dependencies or building the Docker container, fetch the source code from the official GitHub repository:
+
+``` sh
 # clone the project
-$ git clone git@github.com:apache/incubator-teaclave-trustzone-sdk.git
+$ git clone https://github.com/apache/incubator-teaclave-trustzone-sdk.git
 $ cd incubator-teaclave-trustzone-sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,46 +188,15 @@ Note that your OPTEE root directory should have `build/`, `optee_os/` and
 $ ./setup.sh
 ```
 
-#### 3. Set environment variables
+#### 3. Set environment, and build
 
-Before building examples, the environment should be properly setup.
-
-``` sh
-$ source environment
-```
-
-By default, the target platform is `aarch64`. If you want to build for the `arm`
-target, you can setup `ARCH` before `source environment` like this:
+The remaining steps are the same as described in [Getting Started - Set environment variables](#3-set-environment-variables) and  [Getting Started - Build Rust applications](#4-build-rust-applications). Besides, you can collect all example CAs and TAs to `/incubator-teaclave-trustzone-sdk/out`:
 
 ```sh
-$ export ARCH=arm
-$ source environment
-```
-
-#### 4. Build OP-TEE libraries
-
-Then, download ARM toolchains and build OP-TEE libraries. Note that the OP-TEE
-target is QEMUv8, and you can modify the Makefile to other targets accordingly.
-
-``` sh
-$ make optee
-```
-
-#### 5. Build Rust examples
-
-Run this command to build all Rust examples:
-
-``` sh
-$ make examples
-```
-
-Collect all example CAs and TAs to `/incubator-teaclave-trustzone-sdk/out`:
-
-``` sh
 $ make examples-install
 ```
 
-#### 6. Run Rust examples
+#### 4. Run Rust examples
 
 Copy the applications to your platform and run.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ $ source environment
 
 #### 4. Build Rust applications
 
-Before building built-in rust examples, you need to build OP-TEE libraries using:
+Before building built-in rust examples, you need to build OP-TEE libraries
+using:
 
 ``` sh
 $ make optee
@@ -190,7 +191,11 @@ $ ./setup.sh
 
 #### 3. Set environment, and build
 
-The remaining steps are the same as described in [Getting Started - Set environment variables](#3-set-environment-variables) and  [Getting Started - Build Rust applications](#4-build-rust-applications). Besides, you can collect all example CAs and TAs to `/incubator-teaclave-trustzone-sdk/out`:
+Follow the steps described in [Getting Started - Set environment
+variables](#3-set-environment-variables) and  [Getting Started - Build Rust
+applications](#4-build-rust-applications) to set the environment and build both
+the  OP-TEE libraries and the Rust examples. Besides, you can collect all
+example CAs and TAs to `/incubator-teaclave-trustzone-sdk/out`:
 
 ```sh
 $ make examples-install

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ $ source environment
 
 #### 4. Build Rust applications
 
+Before building built-in rust examples, you need to build OP-TEE libraries using:
+
+``` sh
+$ make optee
+```
+
 Run this command to build all Rust examples:
 
 ``` sh


### PR DESCRIPTION
1. Remove some duplicated setup and build commands from `Use OP-TEE libraries as submodules` and refer to `Develop your trusted applications in Rust`.
2. Fix some type and punctuation.
3. Fix problems mentioned in #79.