### PR TITLE
authentication-rs: set nonce size to 8 bytes

### DIFF
--- a/examples/authentication-rs/host/src/main.rs
+++ b/examples/authentication-rs/host/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> optee_teec::Result<()> {
     let mut session = ctx.open_session(uuid)?;
 
     let key = [0xa5u8; KEY_SIZE];
-    let nonce = [0x00u8; 2];
+    let nonce = [0x00u8; 8];
     let aad = [0xffu8; AAD_LEN];
     let clear1 = [0x5au8; BUFFER_SIZE + 3];
     let clear2 = [0xa5u8; BUFFER_SIZE - 3];


### PR DESCRIPTION
The nonce defined in examples/authentication-rs/host/src/main.rs has a size of 2 octets. It turns out that this value is invalid as per RFC 3610 section 2 [1]:

 "Valid values of L range between 2 octets and 8 octets (the value L=1
  is reserved)."
 "A nonce N of 15-L octets"

The two statements above imply than the nonce can only be between 7 and 13 octets.

The AES CCM implementation in LibTomCrypt has recently added stricter validation of the nonce size [2]. As soon as OP-TEE upgrades, the authentication-rs example will fail as follows:
```
 # authentication-rs
 Error: Trusted Application has panicked during the operation. (error code 0xffff3024)

 (Secure console -- call stack processed by optee_os/scripts/symbolize.py)
 [+] TA create
 [+] TA open session
 [+] TA invoke command
 [+] TA prepare
 E/TC:? 0
 E/TC:? 0 TA panicked with code 0xffff0007 (TEE_ERROR_BAD_STATE)
 E/LD:  Status of TA 0a5a06b2-bdab-11eb-add0-77f29de31296
 E/LD:   arch: aarch64
 E/LD:  region  0: va 0x40004000 pa 0x0e326000 size 0x002000 flags rw-s (ldelf)
 E/LD:  region  1: va 0x40006000 pa 0x0e328000 size 0x008000 flags r-xs (ldelf)
 E/LD:  region  2: va 0x4000e000 pa 0x0e330000 size 0x001000 flags rw-s (ldelf)
 E/LD:  region  3: va 0x4000f000 pa 0x0e331000 size 0x004000 flags rw-s (ldelf)
 E/LD:  region  4: va 0x40013000 pa 0x0e335000 size 0x001000 flags r--s
 E/LD:  region  5: va 0x40014000 pa 0x0e36f000 size 0x001000 flags rw-s (stack)
 E/LD:  region  6: va 0x40015000 pa 0x79351f50 size 0x001000 flags rw-- (param)
 E/LD:  region  7: va 0x40016000 pa 0x79351f38 size 0x001000 flags rw-- (param)
 E/LD:  region  8: va 0x40017000 pa 0x79351f4c size 0x001000 flags rw-- (param)
 E/LD:  region  9: va 0x40071000 pa 0x00010000 size 0x02c000 flags r-xs [0] .ta_head .text .eh_frame .rodata .gnu.hash .eh_frame_hdr .dynsym .rela.dyn .rela.got .dynamic .dynstr .hash
 E/LD:  region 10: va 0x4009d000 pa 0x0003c000 size 0x00d000 flags rw-s [0] .data .got .bss
 E/LD:   [0] 0a5a06b2-bdab-11eb-add0-77f29de31296 @ 0x40071000 (out-br/build/optee_rust_examples_ext-1.0/examples/authentication-rs/ta/target/aarch64-unknown-optee-trustzone/release/0a5a06b2-bdab-11eb-add0-77f29de31296.elf)
 E/LD:  Call stack:
 E/LD:   0x400885d8 TEE_AEInit at optee_os/lib/libutee/tee_api_operations.c:1351
 E/LD:   0x4007a3d0 _ZN10optee_utee9crypto_op2AE4init17hffe76700e8394d93E at ta.d4a10f18-cgu.6:?
```
Therefore, pick a different size for the nonce.

Link: [1] https://www.rfc-editor.org/rfc/rfc3610#section-2
Link: [2] https://github.com/libtom/libtomcrypt/commit/9616356abecbd7f068d837965cf79bc8abd6cf59
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>