### PR TITLE
Fix cargo error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,12 @@ jobs:
           mkdir -p ~/bin
           curl https://storage.googleapis.com/git-repo-downloads/repo-1 > ~/bin/repo && chmod a+x ~/bin/repo
           export PATH=~/bin:$PATH
-          mkdir optee-qemuv8 && cd optee-qemuv8 &&
+          mkdir -p ~/optee-qemuv8 && cd ~/optee-qemuv8 &&
           repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml &&
           repo sync -j4 --no-clone-bundle
       - name: Build images and run tests
         run: |
-          cd optee-qemuv8
+          cd ~/optee-qemuv8
           rm -rf optee_rust/ &&
           mv $GITHUB_WORKSPACE/incubator-teaclave-trustzone-sdk optee_rust/
           export OPTEE_DIR=$(pwd)

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ source $HOME/.cargo/env
 rustup component add rust-src && rustup target install aarch64-unknown-linux-gnu arm-unknown-linux-gnueabihf
 
 # install Xargo
-rustup default 1.44.0 && cargo +1.44.0 install xargo
+rustup default 1.56.0 && cargo +1.56.0 install xargo
 # switch to nightly
 rustup default nightly-2021-09-20
 


### PR DESCRIPTION
- Bump rust toolchain version for fixing cargo error: `error[E0658]: use of unstable library feature 'str_strip': newly added`.
- fix ci error: `>>> optee_test_ext 1.0 Building.. make[2]:execvp: /bin/bash: Argument list too long`