### PR TITLE
Add "links" field to Cargo.toml for teec and utee

### DIFF
--- a/optee-teec/optee-teec-sys/Cargo.toml
+++ b/optee-teec/optee-teec-sys/Cargo.toml
@@ -23,6 +23,7 @@ license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
 description = "Native bindings to the libteec library."
 edition = "2018"
+links = "teec"
 
 [dependencies]
 libc = "0.2.48" 

--- a/optee-utee/optee-utee-sys/Cargo.toml
+++ b/optee-utee/optee-utee-sys/Cargo.toml
@@ -23,6 +23,7 @@ license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
 description = "Native bindings to the libutee library."
 edition = "2018"
+links = "utee"
 
 [dependencies]
 libc = { path = "../../rust/libc", version = "=0.2.99" }


### PR DESCRIPTION
This lets dependents with their own way of linking to libteec and/or libutee override our build script if they so choose. See the documentation [here](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts).

This contribution is on behalf of my company.