### PR TITLE
optee-teec: update OP-TEE implementation fields

### DIFF
--- a/optee-teec/optee-teec-sys/src/tee_client_api.rs
+++ b/optee-teec/optee-teec-sys/src/tee_client_api.rs
@@ -80,6 +80,7 @@ pub type TEEC_Result = u32;
 pub struct TEEC_Context {
     pub fd: c_int,
     pub reg_mem: bool,
+    pub memref_null: bool,
 }
 
 #[repr(C)]
@@ -97,6 +98,12 @@ pub struct TEEC_Session {
 }
 
 #[repr(C)]
+pub union SharedMemoryFlagsCompat {
+    dummy: bool,
+    flags: u8,
+}
+
+#[repr(C)]
 pub struct TEEC_SharedMemory {
     pub buffer: *mut c_void,
     pub size: size_t,
@@ -105,7 +112,7 @@ pub struct TEEC_SharedMemory {
     pub alloced_size: size_t,
     pub shadow_buffer: *mut c_void,
     pub registered_fd: c_int,
-    pub buffer_allocated: bool,
+    pub internal: SharedMemoryFlagsCompat,
 }
 
 #[derive(Copy, Clone)]

--- a/optee-teec/src/context.rs
+++ b/optee-teec/src/context.rs
@@ -36,7 +36,7 @@ impl Context {
     /// let ctx = Context::new().unwrap();
     /// ```
     pub fn new() -> Result<Context> {
-        Context::new_raw(0, true).map(|raw| Context { raw })
+        Context::new_raw(0, true, false).map(|raw| Context { raw })
     }
 
     /// Creates a raw TEE client context with implementation defined parameters.
@@ -46,8 +46,12 @@ impl Context {
     /// ```
     /// let raw_ctx: optee_teec_sys::TEEC_Context = Context::new_raw(0, true).unwrap();
     /// ```
-    pub fn new_raw(fd: libc::c_int, reg_mem: bool) -> Result<raw::TEEC_Context> {
-        let mut raw_ctx = raw::TEEC_Context { fd, reg_mem };
+    pub fn new_raw(fd: libc::c_int, reg_mem: bool, memref_null: bool) -> Result<raw::TEEC_Context> {
+        let mut raw_ctx = raw::TEEC_Context {
+            fd,
+            reg_mem,
+            memref_null,
+        };
         unsafe {
             match raw::TEEC_InitializeContext(ptr::null_mut() as *mut libc::c_char, &mut raw_ctx) {
                 raw::TEEC_SUCCESS => Ok(raw_ctx),


### PR DESCRIPTION
We've been updating our OP-TEE version without updating our Rust definitions of its API types. Since the GlobalPlatform TEE Client API uses client-allocated API objects, our code needs to be aware of and match the implementation-specific fields used by the version of libteec we link to.

This pulls in two changes that we missed, one of which increases the space we need to allocate for TEEC_Context and so results in memory unsafety with our current definitions:

 - OP-TEE/optee_client#145
 - OP-TEE/optee_client#217