### PR TITLE
[no-std branch] Further cleanups to allow mixed rust examples builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           export CROSS_COMPILE="aarch64-linux-gnu-"
           export CROSS_COMPILE32="arm-linux-gnueabihf-"
           export CROSS_COMPILE64="aarch64-linux-gnu-"
+          export OPTEE_CLIENT_EXPORT=~/optee_client/out/export/
           ./setup.sh
           . ~/.cargo/env
 
@@ -82,16 +83,34 @@ jobs:
           (cd ~/optee_os && make PLATFORM=vexpress-qemu_armv8a)
           (cd ~/optee_client && make WITH_TEEACL=0)
 
-          # Build Arm 64-bit OP-TEE rust examples
+          # Build OP-TEE rust examples for Arm 64-bit both host and TA
           export TA_DEV_KIT_DIR=~/optee_os/out/arm-plat-vexpress/export-ta_arm64/
-          export OPTEE_CLIENT_EXPORT=~/optee_client/out/export/
           make
 
-          # Build Arm 32-bit OP-TEE rust examples
-          (cd ~/optee_client && make clean && make CROSS_COMPILE=$CROSS_COMPILE32 WITH_TEEACL=0)
+          # Build OP-TEE rust examples for Arm 64-bit host and 32-bit TA
           export TA_DEV_KIT_DIR=~/optee_os/out/arm-plat-vexpress/export-ta_arm32/
-          export OPTEE_CLIENT_EXPORT=~/optee_client/out/export/
-          make clean && make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE32
+          export CROSS_COMPILE_HOST=$CROSS_COMPILE64
+          export CROSS_COMPILE_TA=$CROSS_COMPILE32
+          export TARGET_HOST="aarch64-unknown-linux-gnu"
+          export TARGET_TA="arm-unknown-linux-gnueabihf"
+          make clean && make
+
+          # Build OP-TEE rust examples for Arm 32-bit both host and TA
+          export TA_DEV_KIT_DIR=~/optee_os/out/arm-plat-vexpress/export-ta_arm32/
+          export CROSS_COMPILE_HOST=$CROSS_COMPILE32
+          export CROSS_COMPILE_TA=$CROSS_COMPILE32
+          export TARGET_HOST="arm-unknown-linux-gnueabihf"
+          export TARGET_TA="arm-unknown-linux-gnueabihf"
+          (cd ~/optee_client && make clean && make CROSS_COMPILE=$CROSS_COMPILE32 WITH_TEEACL=0)
+          make clean && make
+
+          # Build OP-TEE rust examples for Arm 32-bit host and 64-bit TA
+          export TA_DEV_KIT_DIR=~/optee_os/out/arm-plat-vexpress/export-ta_arm64/
+          export CROSS_COMPILE_HOST=$CROSS_COMPILE32
+          export CROSS_COMPILE_TA=$CROSS_COMPILE64
+          export TARGET_HOST="arm-unknown-linux-gnueabihf"
+          export TARGET_TA="aarch64-unknown-linux-gnu"
+          make clean && make
 
   build-and-run-examples-in-OPTEE-repo:
     runs-on: ubuntu-latest

--- a/examples/acipher-rs/Makefile
+++ b/examples/acipher-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/acipher-rs/host/Makefile
+++ b/examples/acipher-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := acipher-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/acipher-rs/ta/build.rs
+++ b/examples/acipher-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/aes-rs/Makefile
+++ b/examples/aes-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/aes-rs/host/Makefile
+++ b/examples/aes-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := aes-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/aes-rs/ta/build.rs
+++ b/examples/aes-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/authentication-rs/Makefile
+++ b/examples/authentication-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/authentication-rs/host/Makefile
+++ b/examples/authentication-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := authentication-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/authentication-rs/ta/build.rs
+++ b/examples/authentication-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/big_int-rs/Makefile
+++ b/examples/big_int-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/big_int-rs/host/Makefile
+++ b/examples/big_int-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := big_int-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/big_int-rs/ta/build.rs
+++ b/examples/big_int-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/diffie_hellman-rs/Makefile
+++ b/examples/diffie_hellman-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/diffie_hellman-rs/host/Makefile
+++ b/examples/diffie_hellman-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := diffie_hellman-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/diffie_hellman-rs/ta/build.rs
+++ b/examples/diffie_hellman-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/digest-rs/Makefile
+++ b/examples/digest-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/digest-rs/host/Makefile
+++ b/examples/digest-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := digest-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/digest-rs/ta/build.rs
+++ b/examples/digest-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/hello_world-rs/Makefile
+++ b/examples/hello_world-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/hello_world-rs/host/Makefile
+++ b/examples/hello_world-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := hello_world-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/hello_world-rs/ta/Makefile
+++ b/examples/hello_world-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/hello_world-rs/ta/build.rs
+++ b/examples/hello_world-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/hotp-rs/Makefile
+++ b/examples/hotp-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/hotp-rs/host/Makefile
+++ b/examples/hotp-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := hotp-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/hotp-rs/ta/build.rs
+++ b/examples/hotp-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/random-rs/Makefile
+++ b/examples/random-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/random-rs/host/Makefile
+++ b/examples/random-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := random-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/random-rs/ta/build.rs
+++ b/examples/random-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/secure_storage-rs/Makefile
+++ b/examples/secure_storage-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/secure_storage-rs/host/Makefile
+++ b/examples/secure_storage-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := secure_storage-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/secure_storage-rs/ta/build.rs
+++ b/examples/secure_storage-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/signature_verification-rs/Makefile
+++ b/examples/signature_verification-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/signature_verification-rs/host/Makefile
+++ b/examples/signature_verification-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := signature_verification-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/signature_verification-rs/ta/build.rs
+++ b/examples/signature_verification-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/supp_plugin-rs/Makefile
+++ b/examples/supp_plugin-rs/Makefile
@@ -15,12 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
-	@make -s -C plugin
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C plugin TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
-	@make -s -C plugin clean
+	$(q)make -C host clean
+	$(q)make -C plugin clean
+	$(q)make -C ta clean

--- a/examples/supp_plugin-rs/host/Makefile
+++ b/examples/supp_plugin-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := supp_plugin-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/supp_plugin-rs/plugin/Makefile
+++ b/examples/supp_plugin-rs/plugin/Makefile
@@ -16,18 +16,12 @@
 # under the License.
 
 NAME := syslog_plugin
-ARCH ?= aarch64
 PLUGIN_UUID := `cat ../plugin_uuid.txt`
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../ta_uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/supp_plugin-rs/ta/build.rs
+++ b/examples/supp_plugin-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;

--- a/examples/time-rs/Makefile
+++ b/examples/time-rs/Makefile
@@ -15,10 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+
+# If _HOST or _TA specific compiler/target are not specified, then use common
+# compiler/target for both
+CROSS_COMPILE_HOST ?= $(CROSS_COMPILE)
+CROSS_COMPILE_TA ?= $(CROSS_COMPILE)
+TARGET_HOST ?= $(TARGET)
+TARGET_TA ?= $(TARGET)
+
 all:
-	@make -s -C host
-	@make -s -C ta
+	$(q)make -C host TARGET=$(TARGET_HOST) \
+		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
+	$(q)make -C ta TARGET=$(TARGET_TA) \
+		CROSS_COMPILE=$(CROSS_COMPILE_TA)
 
 clean:
-	@make -s -C host clean
-	@make -s -C ta clean
+	$(q)make -C host clean
+	$(q)make -C ta clean

--- a/examples/time-rs/host/Makefile
+++ b/examples/time-rs/host/Makefile
@@ -16,17 +16,11 @@
 # under the License.
 
 NAME := time-rs
-ARCH ?= aarch64
 
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)gcc\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)gcc\"
-endif
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -17,20 +17,13 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-ARCH ?= aarch64
-
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)ld.bfd\"
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-
-ifeq ($(ARCH), arm)
-	TARGET := arm-unknown-linux-gnueabihf
-	LINKER_CFG := target.arm-unknown-linux-gnueabihf.linker=\"$(CROSS_COMPILE)ld.bfd\"
-else
-	TARGET := aarch64-unknown-linux-gnu
-	LINKER_CFG := target.aarch64-unknown-linux-gnu.linker=\"$(CROSS_COMPILE)ld.bfd\"
-endif
-
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 all: ta strip sign

--- a/examples/time-rs/ta/build.rs
+++ b/examples/time-rs/ta/build.rs
@@ -51,8 +51,8 @@ fn main() -> std::io::Result<()> {
     let f = File::open(optee_os_path.join("src/ta.ld.S"))?;
     let f = BufReader::new(f);
 
-    match env::var("ARCH") {
-        Ok(ref v) if v == "arm" => {
+    match env::var("TARGET") {
+        Ok(ref v) if v == "arm-unknown-linux-gnueabihf" => {
             println!("cargo:rustc-link-arg=--no-warn-mismatch");
             for line in f.lines() {
                 let l = line?;


### PR DESCRIPTION
Extend Makefile infrastructure to support different combinations for host and TA rust targets. Following environment variables are added:
- TARGET_HOST
- TARGET_TA
- CROSS_COMPILE_HOST
- CROSS_COMPILE_TA