### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,32 +22,32 @@ defaults:
     shell: bash
 
 jobs:
-#  build-and-run-examples:
-#    runs-on: ubuntu-20.04
-#    container: teaclave/teaclave-trustzone-sdk-build:0.3.0
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v2
-#        with:
-#          submodules: recursive
-#      - name: Setting up $HOME
-#        run: |
-#          cp /root/.bashrc $HOME/.bashrc &&
-#          ln -sf /root/.rustup ~/.rustup &&
-#          ln -sf /root/.cargo ~/.cargo
-#      - name: Building
-#        run: |
-#          apt update && apt install libslirp-dev -y
-#          export CARGO_NET_GIT_FETCH_WITH_CLI=true &&
-#          ./setup.sh &&
-#          source environment &&
-#          make optee &&
-#          . ~/.cargo/env &&
-#          make examples
-#      - name: Run tests and examples
-#        run: |
-#          cd ci && ./ci.sh
-  build-utee-teec:
+   build-and-run-examples:
+     runs-on: ubuntu-20.04
+     container: teaclave/teaclave-trustzone-sdk-build:0.3.0
+     steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+         with:
+           submodules: recursive
+       - name: Setting up $HOME
+         run: |
+           cp /root/.bashrc $HOME/.bashrc &&
+           ln -sf /root/.rustup ~/.rustup &&
+           ln -sf /root/.cargo ~/.cargo
+       - name: Building
+         run: |
+           apt update && apt install libslirp-dev -y
+           export CARGO_NET_GIT_FETCH_WITH_CLI=true &&
+           ./setup.sh &&
+           source environment &&
+           make optee &&
+           . ~/.cargo/env &&
+           make examples
+       - name: Run tests and examples
+         run: |
+           cd ci && ./ci.sh
+   build-utee-teec:
     runs-on: ubuntu-20.04
     container: teaclave/teaclave-trustzone-sdk-build:0.3.0
     steps:
@@ -69,39 +69,7 @@ jobs:
           . ~/.cargo/env &&
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
-  build-and-run-examples-in-OPTEE-repo:
-    runs-on: ubuntu-20.04
-    container: teaclave/teaclave-trustzone-sdk-build:0.3.0
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          path: 'incubator-teaclave-trustzone-sdk'
-      - name: Checkout OP-TEE repository
-        run: |
-          mkdir -p ~/bin
-          curl https://storage.googleapis.com/git-repo-downloads/repo-1 > ~/bin/repo && chmod a+x ~/bin/repo
-          export PATH=~/bin:$PATH
-          mkdir -p ~/optee-qemuv8 && cd ~/optee-qemuv8 &&
-          repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml &&
-          repo sync -j4 --no-clone-bundle
-      - name: Setting up $HOME
-        run: |
-          cp /root/.bashrc $HOME/.bashrc &&
-          ln -sf /root/.rustup ~/.rustup &&
-          ln -sf /root/.cargo ~/.cargo
-      - name: Build images and run tests
-        run: |
-          apt update && apt install libslirp-dev -y
-          cd ~/optee-qemuv8
-          rm -rf optee_rust/ &&
-          mv $GITHUB_WORKSPACE/incubator-teaclave-trustzone-sdk optee_rust/
-          export OPTEE_DIR=$(pwd)
-          cd build &&
-          make -j2 toolchains &&
-          make CFG_TEE_CORE_LOG_LEVEL=0 OPTEE_RUST_ENABLE=y CFG_TEE_RAM_VA_SIZE=0x00300000 check-rust
-  license:
+   license:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since the `no-std` branch is tested on OPTEE repo upstream, for `master` (std) we use our testing environment (pre-built QEMU img)