### PR TITLE
RFC: An effort to allow reuse for common OP-TEE crates

### DIFF
--- a/environment
+++ b/environment
@@ -24,6 +24,7 @@ fi
 export OPTEE_OS_DIR="$OPTEE_DIR/optee_os"
 export OPTEE_CLIENT_DIR="$OPTEE_DIR/optee_client/out"
 export OPTEE_CLIENT_INCLUDE="$OPTEE_DIR/optee_client/out/export/usr/include"
+export OPTEE_CLIENT_EXPORT="$OPTEE_DIR/optee_client/out/export"
 if [ "$ARCH" = "arm" ]
 then
   export ARCH="arm"
@@ -31,6 +32,7 @@ then
   export VENDOR="qemu.mk"
   export OPTEE_OS_INCLUDE="$OPTEE_DIR/optee_os/out/arm/export-ta_arm32/include"
   export CC=$OPTEE_DIR/toolchains/aarch32/bin/arm-linux-gnueabihf-gcc
+  export TA_DEV_KIT_DIR="$OPTEE_OS_DIR/out/arm/export-ta_arm32"
 else
   # export ARCH="aarch64" # comment this because currently optee_os cannot be compiled in the aarch64 target
   unset ARCH
@@ -38,4 +40,5 @@ else
   export VENDOR="qemu_v8.mk"
   export OPTEE_OS_INCLUDE="$OPTEE_DIR/optee_os/out/arm/export-ta_arm64/include"
   export CC=$OPTEE_DIR/toolchains/aarch64/bin/aarch64-linux-gnu-gcc
+  export TA_DEV_KIT_DIR="$OPTEE_OS_DIR/out/arm/export-ta_arm64"
 fi

--- a/examples/acipher-rs/host/Cargo.toml
+++ b/examples/acipher-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/acipher-rs/ta/Cargo.toml
+++ b/examples/acipher-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/acipher-rs/ta/src/main.rs
+++ b/examples/acipher-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/aes-rs/host/Cargo.toml
+++ b/examples/aes-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/aes-rs/ta/Cargo.toml
+++ b/examples/aes-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/aes-rs/ta/src/main.rs
+++ b/examples/aes-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/authentication-rs/host/Cargo.toml
+++ b/examples/authentication-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/authentication-rs/ta/Cargo.toml
+++ b/examples/authentication-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/authentication-rs/ta/src/main.rs
+++ b/examples/authentication-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/big_int-rs/host/Cargo.toml
+++ b/examples/big_int-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/big_int-rs/ta/Cargo.toml
+++ b/examples/big_int-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/big_int-rs/ta/src/main.rs
+++ b/examples/big_int-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::BigInt;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,

--- a/examples/diffie_hellman-rs/host/Cargo.toml
+++ b/examples/diffie_hellman-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/diffie_hellman-rs/ta/Cargo.toml
+++ b/examples/diffie_hellman-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/diffie_hellman-rs/ta/src/main.rs
+++ b/examples/diffie_hellman-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/digest-rs/host/Cargo.toml
+++ b/examples/digest-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/digest-rs/ta/Cargo.toml
+++ b/examples/digest-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/digest-rs/ta/src/main.rs
+++ b/examples/digest-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/hello_world-rs/host/Cargo.toml
+++ b/examples/hello_world-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/hello_world-rs/ta/Cargo.toml
+++ b/examples/hello_world-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/hello_world-rs/ta/src/main.rs
+++ b/examples/hello_world-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/hotp-rs/host/Cargo.toml
+++ b/examples/hotp-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/hotp-rs/ta/Cargo.toml
+++ b/examples/hotp-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/hotp-rs/ta/src/main.rs
+++ b/examples/hotp-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/message_passing_interface-rs/host/Cargo.toml
+++ b/examples/message_passing_interface-rs/host/Cargo.toml
@@ -28,4 +28,4 @@ edition = "2018"
 libc = "0.2.48"
 url = "1.7.2"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }

--- a/examples/message_passing_interface-rs/ta/Cargo.toml
+++ b/examples/message_passing_interface-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/message_passing_interface-rs/ta/src/main.rs
+++ b/examples/message_passing_interface-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/random-rs/host/Cargo.toml
+++ b/examples/random-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/random-rs/ta/Cargo.toml
+++ b/examples/random-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/random-rs/ta/src/main.rs
+++ b/examples/random-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/secure_storage-rs/host/Cargo.toml
+++ b/examples/secure_storage-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/secure_storage-rs/ta/Cargo.toml
+++ b/examples/secure_storage-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/secure_storage-rs/ta/src/main.rs
+++ b/examples/secure_storage-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/serde-rs/host/Cargo.toml
+++ b/examples/serde-rs/host/Cargo.toml
@@ -29,7 +29,7 @@ libc = "0.2.48"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/serde-rs/ta/Cargo.toml
+++ b/examples/serde-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/signature_verification-rs/host/Cargo.toml
+++ b/examples/signature_verification-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/signature_verification-rs/ta/Cargo.toml
+++ b/examples/signature_verification-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 ring = { git = "https://github.com/veracruz-project/ring.git", branch = "veracruz", version = "=0.16.11", features = ["std"] }
 
 [build_dependencies]
@@ -40,7 +40,7 @@ lto = true
 opt-level = 1
 
 [patch."https://github.com/veracruz-project/rust-optee-trustzone-sdk.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 libc = { path = "../../../rust/libc" }
 [patch."https://github.com/veracruz-project/ring.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }

--- a/examples/signature_verification-rs/ta/src/main.rs
+++ b/examples/signature_verification-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use ring::signature::KeyPair;
 use ring::{rand, signature};
 

--- a/examples/supp_plugin-rs/host/Cargo.toml
+++ b/examples/supp_plugin-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/supp_plugin-rs/ta/Cargo.toml
+++ b/examples/supp_plugin-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/supp_plugin-rs/ta/src/main.rs
+++ b/examples/supp_plugin-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/tcp_client-rs/host/Cargo.toml
+++ b/examples/tcp_client-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/tcp_client-rs/ta/Cargo.toml
+++ b/examples/tcp_client-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/tcp_client-rs/ta/src/main.rs
+++ b/examples/tcp_client-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/time-rs/host/Cargo.toml
+++ b/examples/time-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/time-rs/ta/Cargo.toml
+++ b/examples/time-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/time-rs/ta/src/main.rs
+++ b/examples/time-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::Time;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,

--- a/examples/tls_client-rs/host/Cargo.toml
+++ b/examples/tls_client-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/tls_client-rs/ta/Cargo.toml
+++ b/examples/tls_client-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 rustls = { git = "https://github.com/DemesneGH/rustls.git", branch = "veracruz" }
 webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "veracruz", features = ["default"] }
@@ -43,8 +43,8 @@ lto = true
 
 # Patch optee-utee for webpki
 [patch."https://github.com/veracruz-project/rust-optee-trustzone-sdk.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 # Patch optee-utee for rustls
 [patch."https://github.com/apache/incubator-teaclave-trustzone-sdk.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }

--- a/examples/tls_client-rs/ta/src/main.rs
+++ b/examples/tls_client-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::net::TcpStream;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,

--- a/examples/tls_server-rs/host/Cargo.toml
+++ b/examples/tls_server-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/tls_server-rs/ta/Cargo.toml
+++ b/examples/tls_server-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 rustls = { git = "https://github.com/DemesneGH/rustls.git", branch = "veracruz" }
 webpki = { git = "https://github.com/veracruz-project/webpki.git", branch = "veracruz", features = ["default"] }
@@ -44,8 +44,8 @@ lto = true
 
 # Patch optee-utee for webpki
 [patch."https://github.com/veracruz-project/rust-optee-trustzone-sdk.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 # Patch optee-utee for rustls
 [patch."https://github.com/apache/incubator-teaclave-trustzone-sdk.git"]
-optee-utee = { path = "../../../optee-utee" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }

--- a/examples/tls_server-rs/ta/src/main.rs
+++ b/examples/tls_server-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };

--- a/examples/udp_socket-rs/host/Cargo.toml
+++ b/examples/udp_socket-rs/host/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 [dependencies]
 libc = "0.2.48"
 proto = { path = "../proto" }
-optee-teec = { path = "../../../optee-teec" }
+optee-teec = { git = "https://github.com/b49020/optee-teec/" }
 
 [profile.release]
 lto = true

--- a/examples/udp_socket-rs/ta/Cargo.toml
+++ b/examples/udp_socket-rs/ta/Cargo.toml
@@ -27,8 +27,8 @@ edition = "2018"
 [dependencies]
 libc = { path = "../../../rust/libc" }
 proto = { path = "../proto" }
-optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
-optee-utee = { path = "../../../optee-utee" }
+optee-utee-sys = { git = "https://github.com/b49020/optee-utee/" }
+optee-utee = { git = "https://github.com/b49020/optee-utee/" }
 
 [build_dependencies]
 uuid = { version = "0.8" }

--- a/examples/udp_socket-rs/ta/src/main.rs
+++ b/examples/udp_socket-rs/ta/src/main.rs
@@ -17,6 +17,7 @@
 
 #![no_main]
 
+use std::os::raw::c_void;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };


### PR DESCRIPTION
I would propose to have separate git repos for `optee-utee` and `optee-teec` crates such that they can be reused by both `std` and `no-std` OP-TEE Rust examples. This would allow us to avoid divergent OP-TEE crates and rather have single git repos to provide collaborative development environment.

For demonstration purpose, I have created two repos using `git subtree split` command as follows:
- https://github.com/b49020/optee-teec
- https://github.com/b49020/optee-utee

@DemesneGH If you are fine with this approach then please create corresponding 2 new repos for these crates and I will create PRs for those. Once those are in place then we can drop `optee-utee` and `optee-teec` sub-directories from both `master` and `no-std` branch.