### PR TITLE
examples: ensure the proper build order

### DIFF
--- a/examples/acipher-rs/host/Makefile
+++ b/examples/acipher-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/aes-rs/host/Makefile
+++ b/examples/aes-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/authentication-rs/host/Makefile
+++ b/examples/authentication-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/big_int-rs/host/Makefile
+++ b/examples/big_int-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/diffie_hellman-rs/host/Makefile
+++ b/examples/diffie_hellman-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/digest-rs/host/Makefile
+++ b/examples/digest-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/hello_world-rs/host/Makefile
+++ b/examples/hello_world-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/hello_world-rs/ta/Makefile
+++ b/examples/hello_world-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/hotp-rs/host/Makefile
+++ b/examples/hotp-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/random-rs/host/Makefile
+++ b/examples/random-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/secure_storage-rs/host/Makefile
+++ b/examples/secure_storage-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/signature_verification-rs/host/Makefile
+++ b/examples/signature_verification-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/supp_plugin-rs/host/Makefile
+++ b/examples/supp_plugin-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 

--- a/examples/time-rs/host/Makefile
+++ b/examples/time-rs/host/Makefile
@@ -30,7 +30,7 @@ all: host strip
 host:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: host
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
 
 clean:

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -31,10 +31,10 @@ all: ta strip sign
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
-strip:
+strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
 
-sign:
+sign: strip
 	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
 	@echo "SIGN =>  ${UUID}"
 


### PR DESCRIPTION
The Makefiles for the examples lacked dependencies between rules, resulting in some cases resulted in build error. To maintain a coherent build process, this commit introduces dependencies to ensure that binaries are built before being stripped and signed.