### PR TITLE
Add missing identifiers for RSA and elliptic curves

### DIFF
--- a/optee-utee/src/crypto_op.rs
+++ b/optee-utee/src/crypto_op.rs
@@ -1650,6 +1650,9 @@ pub enum AlgorithmId {
     Des3CbcMacPkcs5 = 0x30000513,
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    RsassaPkcs1V15 = 0xF0000830,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
     RsassaPkcs1V15MD5 = 0x70001830,
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
@@ -1671,6 +1674,9 @@ pub enum AlgorithmId {
     RsassaPkcs1V15MD5Sha1 = 0x7000F830,
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    RsassaPkcs1PssMgf1MD5 = 0xF0111930,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
     RsassaPkcs1PssMgf1Sha1 = 0x70212930,
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
@@ -1687,6 +1693,9 @@ pub enum AlgorithmId {
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Encrypt](OperationMode::Encrypt) or [Decrypt](OperationMode::Decrypt) mode.
     RsaesPkcs1V15 = 0x60000130,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Encrypt](OperationMode::Encrypt) or [Decrypt](OperationMode::Decrypt) mode.
+    RsaesPkcs1OAepMgf1MD5 = 0xF0110230,
     /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
     /// [Encrypt](OperationMode::Encrypt) or [Decrypt](OperationMode::Decrypt) mode.
     RsaesPkcs1OAepMgf1Sha1 = 0x60210230,
@@ -1716,6 +1725,28 @@ pub enum AlgorithmId {
     DSASha256 = 0x70004131,
     /// [DeriveKey](DeriveKey) supported algorithm.
     DhDeriveSharedSecret = 0x80000032,
+    /// [DeriveKey](DeriveKey) supported algorithm.
+    EcDhDeriveSharedSecret = 0x80000042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    EcDsaSha1 = 0x70001042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    EcDsaSha224 = 0x70002042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    EcDsaSha256 = 0x70003042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    EcDsaSha384 = 0x70004042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    EcDsaSha512 = 0x70005042,
+    /// [Asymmetric](Asymmetric) supported algorithm, can be applied with
+    /// [Sign](OperationMode::Sign) or [Verify](OperationMode::Verify) mode.
+    Ed25519 = 0x70006043,
+    /// [DeriveKey](DeriveKey) supported algorithm.
+    X25519 = 0x80000044,
     /// [Digest](Digest) supported algorithm.
     Md5 = 0x50000001,
     /// [Digest](Digest) supported algorithm.
@@ -1762,4 +1793,6 @@ pub enum ElementId {
     EccCurveNistP384 = 0x00000004,
     /// Source: `NIST`, Generic: `Y`, Size: 521 bits
     EccCurveNistP521 = 0x00000005,
+    /// Source: `IETF`, Generic: `N`, Size: 256 bits
+    EccCurve25519 = 0x00000300,
 }

--- a/optee-utee/src/object.rs
+++ b/optee-utee/src/object.rs
@@ -398,11 +398,22 @@ pub enum AttributeId {
     /// Diffie-Hellman public value: `x`
     DhPrivateValue = 0xC0000232,
     RsaOaepLabel = 0xD0000930,
+    RsaOaepMgf1Hash = 0xD0000931,
     RsaPssSaltLength = 0xF0000A30,
+    /// ECC public value: `x`
     EccPublicValueX = 0xD0000141,
+    /// ECC public value: `y`
     EccPublicValueY = 0xD0000241,
     /// ECC private value: `d`
     EccPrivateValue = 0xC0000341,
+    /// Ed25519 public value
+    Ed25519PublicValue = 0xD0000743,
+    /// Ed25519 private value
+    Ed25519PrivateValue = 0xC0000843,
+    /// X25519 public value
+    X25519PublicValue = 0xD0000944,
+    /// X25519 private value
+    X25519PrivateValue = 0xC0000A44,
     /// ECC Curve algorithm
     EccCurve = 0xF0000441,
     BitProtected = (1 << 28),
@@ -462,6 +473,18 @@ pub enum TransientObjectType {
     /// one of the ECC curves defined in Table 6-14 with "generic" equal to
     /// "Y" is supported. SHALL be same value as for ECDH public key size
     EcdhKeypair = 0xA1000042,
+    /// 256 bits. Conditional: Available only if TEE_ECC_CURVE_25519
+    /// defined in Table 6-14 is supported.
+    Ed25519PublicKey = 0xA0000043,
+    /// 256 bits. Conditional: Available only if TEE_ECC_CURVE_25519
+    /// defined in Table 6-14 is supported.
+    Ed25519Keypair = 0xA1000043,
+    /// 256 bits. Conditional: Available only if TEE_ECC_CURVE_25519
+    /// defined in Table 6-14 is supported.
+    X25519PublicKey = 0xA0000044,
+    /// 256 bits. Conditional: Available only if TEE_ECC_CURVE_25519
+    /// defined in Table 6-14 is supported.
+    X25519Keypair = 0xA1000044,
     /// Multiple of 8 bits, up to 4096 bits. This type is intended for secret
     /// data that has been derived from a key derivation scheme.
     GenericSecret = 0xA0000000,


### PR DESCRIPTION
optee-utee is missing a few algorithm and attribute identifiers required for implementing AOSP KeyMint TA [1].  Add the missing RSA and ECC constants.

[1] https://android.googlesource.com/platform/system/keymint/