### PR TITLE
Update to OP-TEE 4.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,13 @@ jobs:
            submodules: recursive
        - name: Setting up $HOME
          run: |
-           cp /root/.bashrc $HOME/.bashrc &&
-           ln -sf /root/.rustup ~/.rustup &&
-           ln -sf /root/.cargo ~/.cargo
+           cp /root/.bashrc $HOME/.bashrc
        - name: Building
          run: |
            export CARGO_NET_GIT_FETCH_WITH_CLI=true &&
            ./setup.sh &&
            source environment &&
            make optee &&
-           . ~/.cargo/env &&
            make examples
        - name: Run tests and examples
          run: |
@@ -56,16 +53,13 @@ jobs:
           submodules: recursive
       - name: Setting up $HOME
         run: |
-          cp /root/.bashrc $HOME/.bashrc &&
-          ln -sf /root/.rustup ~/.rustup &&
-          ln -sf /root/.cargo ~/.cargo
+          cp /root/.bashrc $HOME/.bashrc
       - name: Building
         run: |
           export CARGO_NET_GIT_FETCH_WITH_CLI=true &&
           ./setup.sh &&
           source environment &&
           make optee &&
-          . ~/.cargo/env &&
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
    license:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ defaults:
 
 jobs:
    build-and-run-examples:
-     runs-on: ubuntu-24.04
+     runs-on: ubuntu-latest
      container: yuanz0/teaclave-trustzone-sdk:ubuntu-24.04
      steps:
        - name: Checkout repository
@@ -47,7 +47,7 @@ jobs:
          run: |
            cd ci && ./ci.sh
    build-utee-teec:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: yuanz0/teaclave-trustzone-sdk:ubuntu-24.04
     steps:
       - name: Checkout repository
@@ -69,7 +69,7 @@ jobs:
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
    license:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check License Header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ defaults:
 
 jobs:
    build-and-run-examples:
-     runs-on: ubuntu-20.04
-     container: teaclave/teaclave-trustzone-sdk-build:0.3.0
+     runs-on: ubuntu-24.04
+     container: yuanz0/teaclave-trustzone-sdk:ubuntu-24.04
      steps:
        - name: Checkout repository
          uses: actions/checkout@v2
@@ -37,7 +37,6 @@ jobs:
            ln -sf /root/.cargo ~/.cargo
        - name: Building
          run: |
-           apt update && apt install libslirp-dev -y
            export CARGO_NET_GIT_FETCH_WITH_CLI=true &&
            ./setup.sh &&
            source environment &&
@@ -48,8 +47,8 @@ jobs:
          run: |
            cd ci && ./ci.sh
    build-utee-teec:
-    runs-on: ubuntu-20.04
-    container: teaclave/teaclave-trustzone-sdk-build:0.3.0
+    runs-on: ubuntu-24.04
+    container: yuanz0/teaclave-trustzone-sdk:ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -70,7 +69,7 @@ jobs:
           (cd optee-utee && xargo build --target aarch64-unknown-optee-trustzone -vv) &&
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)
    license:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Check License Header

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 MAINTAINER Teaclave Contributors <dev@teaclave.apache.org>
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -53,15 +53,12 @@ RUN apt-get update && \
     libtool \
     make \
     mtools \
-    netcat \
     ninja-build \
-    python \
-    python-crypto \
-    python3-crypto \
-    python-pyelftools \
+    python3 \
     python3-pycryptodome \
     python3-pyelftools \
     python3-serial \
+    python3-cryptography \
     rsync \
     unzip \
     uuid-dev \
@@ -72,26 +69,9 @@ RUN apt-get update && \
     wget \
     cpio \
     libcap-ng-dev \
+    libslirp-dev \
     screen \
     libvdeplug-dev \
     libsdl2-dev \
     pip \
     ca-certificates
-
-RUN pip install cryptography
-
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository ppa:linuxuprising/libpng12 && \
-    apt-get update && \
-    apt-get install libpng12-0
-
-# Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-  . $HOME/.cargo/env && \
-  rustup default nightly-2021-09-20 && \
-  rustup component add rust-src && \
-  rustup target install aarch64-unknown-linux-gnu && \
-  rustup default 1.44.0 && cargo +1.44.0 install xargo && \
-  rustup default nightly-2021-09-20
-
-ENV PATH="/root/.cargo/bin:$PATH"

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -40,5 +40,7 @@ pushd ../tests
 ./test_supp_plugin.sh
 ./test_tls_client.sh
 ./test_tls_server.sh
+echo "All tests passed!"
+./cleanup_all.sh
 
 popd

--- a/environment
+++ b/environment
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+export PATH=$PATH:$HOME/.cargo/bin
 export RUST_TARGET_PATH="$(pwd)"
 export RUST_COMPILER_RT_ROOT=$RUST_TARGET_PATH/rust/rust/src/llvm-project/compiler-rt
 if [ -z "$OPTEE_DIR" ]

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ cargo +stable install xargo
 
 ########################################################
 # initialize submodules: optee_os / optee_client / build
-OPTEE_RELEASE_VERSION=3.20.0
+OPTEE_RELEASE_VERSION=4.2.0
 
 if [[ -z "$OPTEE_DIR" ]] || [[ "$OPTEE_DIR" == "$(pwd)/optee" ]]
 then

--- a/tests/cleanup_all.sh
+++ b/tests/cleanup_all.sh
@@ -17,19 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cd $1 && ./qemu-system-aarch64 \
-    -nodefaults \
-    -nographic \
-    -serial stdio -serial file:/tmp/serial.log \
-    -smp 2 \
-    -s -machine virt,secure=on,gic-version=3 -cpu cortex-a57 \
-    -d unimp -semihosting-config enable=on,target=native \
-    -m 1057 \
-    -bios bl1.bin \
-    -initrd rootfs.cpio.gz \
-    -append 'console=ttyAMA0,38400 keep_bootcon root=/dev/vda2' \
-    -kernel Image -no-acpi \
-    -fsdev local,id=fsdev0,path=$(pwd)/../shared,security_model=none \
-    -device virtio-9p-device,fsdev=fsdev0,mount_tag=host \
-    -netdev user,id=vmnic,hostfwd=:127.0.0.1:54433-:4433 \
-    -device virtio-net-device,netdev=vmnic
+set -xe
+
+rm -rf screenlog.0 shared
+rm -rf optee-qemuv8-*

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -xe
+
+# Default value for NEED_EXPANDED_MEM
+: ${NEED_EXPANDED_MEM:=false}
+
+# Define IMG_VERSION
+IMG_VERSION="optee-qemuv8-4.2.0-ubuntu-24.04"
+
+# Set IMG based on NEED_EXPANDED_MEM
+if [ "$NEED_EXPANDED_MEM" = true ]; then
+    IMG="${IMG_VERSION}-expand-ta-memory"
+else
+    IMG="$IMG_VERSION"
+fi
+
+# Function to download image
+download_image() {
+    curl "https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/${IMG}.tar.gz" | tar zxv
+}
+
+# Functions for running commands in QEMU screen
+run_in_qemu() {
+    screen -S qemu_screen -p 0 -X stuff "$1\n"
+    sleep 5
+}
+
+# Check if the image file exists locally
+if [ ! -d "${IMG}" ]; then
+    echo "Image file '${IMG}' not found locally. Downloading from network."
+    download_image
+else
+    echo "Image file '${IMG}' found locally."
+fi
+
+mkdir -p shared
+
+# Start QEMU screen
+screen -L -d -m -S qemu_screen ./optee-qemuv8.sh $IMG
+sleep 30
+run_in_qemu "root"
+run_in_qemu "mkdir -p shared && mount -t 9p -o trans=virtio host shared && cd shared"

--- a/tests/test_acipher.sh
+++ b/tests/test_acipher.sh
@@ -19,37 +19,26 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/acipher-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/acipher-rs/host/target/aarch64-unknown-linux-gnu/release/acipher-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./acipher-rs 256 teststring\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./acipher-rs 256 teststring\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Success encrypt input text \".*\" as [0-9]* bytes cipher text:" screenlog.0 &&
-	grep -q "Success decrypt the above ciphertext as [0-9]* bytes plain text:" screenlog.0	
+    grep -q "Success encrypt input text \".*\" as [0-9]* bytes cipher text:" screenlog.0 &&
+    grep -q "Success decrypt the above ciphertext as [0-9]* bytes plain text:" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
-        false
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
+    false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_aes.sh
+++ b/tests/test_aes.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/aes-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/aes-rs/host/target/aarch64-unknown-linux-gnu/release/aes-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./aes-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./aes-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Prepare encode operation" screenlog.0 &&
 	grep -q "Load key in TA" screenlog.0 &&
@@ -54,6 +45,4 @@ sleep 5
 	false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_authentication.sh
+++ b/tests/test_authentication.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/authentication-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/authentication-rs/host/target/aarch64-unknown-linux-gnu/release/authentication-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./authentication-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./authentication-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Clear text and decoded text match" screenlog.0 &&
 	grep -q "Success" screenlog.0
@@ -50,6 +41,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_big_int.sh
+++ b/tests/test_big_int.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/big_int-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/big_int-rs/host/target/aarch64-unknown-linux-gnu/release/big_int-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./big_int-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./big_int-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "\[.*] > \[.*]\|\[.*] < \[.*]\|\[.*] == \[.*]" /tmp/serial.log &&
 	grep -q "\[.*] in u8 array is \[.*]" /tmp/serial.log &&
@@ -57,6 +48,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_diffie_hellman.sh
+++ b/tests/test_diffie_hellman.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/diffie_hellman-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/diffie_hellman-rs/host/target/aarch64-unknown-linux-gnu/release/diffie_hellman-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./diffie_hellman-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./diffie_hellman-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "get key [0|1] pair as public: \[.*], private: \[.*]" screenlog.0 &&
 	grep -q "Derived share key as \[.*]" screenlog.0 &&
@@ -51,6 +42,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_digest.sh
+++ b/tests/test_digest.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/digest-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/digest-rs/host/target/aarch64-unknown-linux-gnu/release/digest-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./digest-rs message1 message2\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./digest-rs message1 message2\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Get message hash as:" screenlog.0 &&
 	grep -q "Success" screenlog.0
@@ -50,6 +41,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_hello_world.sh
+++ b/tests/test_hello_world.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/hello_world-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/hello_world-rs/host/target/aarch64-unknown-linux-gnu/release/hello_world-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./hello_world-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./hello_world-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "original value is 29" screenlog.0 &&
 	grep -q "inc value is 129" screenlog.0 &&
@@ -52,6 +43,4 @@ sleep 5
 	false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_hotp.sh
+++ b/tests/test_hotp.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/hotp-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/hotp-rs/host/target/aarch64-unknown-linux-gnu/release/hotp-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./hotp-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./hotp-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Get HOTP" screenlog.0 &&
 	grep -q "Success" screenlog.0
@@ -50,6 +41,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_message_passing_interface.sh
+++ b/tests/test_message_passing_interface.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/message_passing_interface-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/message_passing_interface-rs/host/target/aarch64-unknown-linux-gnu/release/message_passing_interface-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./message_passing_interface-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./message_passing_interface-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Hello, World" screenlog.0
 } || {
@@ -49,6 +40,4 @@ sleep 5
 	false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_random.sh
+++ b/tests/test_random.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/random-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/random-rs/host/target/aarch64-unknown-linux-gnu/release/random-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./random-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./random-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Invoking TA to generate random UUID" screenlog.0 &&
 	grep -q "Generate random UUID: [a-z0-9]*-[a-z0-9]*-[a-z0-9]*-[a-z0-9]*" screenlog.0 &&
@@ -51,6 +42,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_secure_storage.sh
+++ b/tests/test_secure_storage.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/secure_storage-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/secure_storage-rs/host/target/aarch64-unknown-linux-gnu/release/secure_storage-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./secure_storage-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./secure_storage-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Test on object \"object#1\"" screenlog.0 &&
 	grep -q "\- Create and load object in the TA secure storage" screenlog.0 &&
@@ -59,6 +50,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_signature_verification.sh
+++ b/tests/test_signature_verification.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/signature_verification-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/signature_verification-rs/host/target/aarch64-unknown-linux-gnu/release/signature_verification-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./signature_verification-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./signature_verification-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Success" screenlog.0
 } || {
@@ -49,6 +40,4 @@ sleep 5
 	false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_tcp_client.sh
+++ b/tests/test_tcp_client.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/tcp_client-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/tcp_client-rs/host/target/aarch64-unknown-linux-gnu/release/tcp_client-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./tcp_client-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./tcp_client-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Success" screenlog.0
 } || {
@@ -49,6 +40,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_time.sh
+++ b/tests/test_time.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/time-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/time-rs/host/target/aarch64-unknown-linux-gnu/release/time-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./time-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./time-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Success" screenlog.0 &&
 	grep -q "\[+] Get REE time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log &&
@@ -53,6 +44,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_tls_client.sh
+++ b/tests/test_tls_client.sh
@@ -19,28 +19,20 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+NEED_EXPANDED_MEM=true
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04-expand-ta-memory.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/tls_client-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/tls_client-rs/host/target/aarch64-unknown-linux-gnu/release/tls_client-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./tls_client-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./tls_client-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Success" screenlog.0
 } || {
@@ -49,6 +41,4 @@ sleep 5
 	false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_udp_socket.sh
+++ b/tests/test_udp_socket.sh
@@ -19,28 +19,19 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/udp_socket-rs/ta/target/aarch64-unknown-optee-trustzone/release/*.ta shared
 cp ../examples/udp_socket-rs/host/target/aarch64-unknown-linux-gnu/release/udp_socket-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./udp_socket-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./udp_socket-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
 	grep -q "Success" screenlog.0
 } || {
@@ -49,6 +40,4 @@ sleep 5
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0


### PR DESCRIPTION
- update to OP-TEE 4.2.0
- simplify test scripts
- use new docker img based on Ubuntu 24.04 (required by qemu libslirp)