### PR TITLE
[no-std] Simplify test scripts

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -34,5 +34,6 @@ pushd ../tests
 ./test_time.sh
 ./test_signature_verification.sh
 ./test_supp_plugin.sh
+./test_error_handling.sh
 
 popd

--- a/ci/qemu-check.exp
+++ b/ci/qemu-check.exp
@@ -245,4 +245,17 @@ expect {
 	}
 }
 
+expect "# "
+info "Running error_handling-rs...\n"
+send -- "error_handling-rs\r"
+expect {
+	"Test passed" {
+		info "Test success\n"
+	}
+	timeout {
+		info "!!! Timeout: Test failed\n"
+		exit 1
+	}
+}
+
 info "Test Rust application finished\n"

--- a/examples/error_handling-rs/host/src/main.rs
+++ b/examples/error_handling-rs/host/src/main.rs
@@ -40,4 +40,6 @@ fn test_error_handling() {
     // Test repeated error invocation also returns the requested error.
     let e = session.invoke_command(Command::ReturnGenericError as u32, &mut operation).expect_err("generic error");
     assert_eq!(e.kind(), ErrorKind::Generic);
+
+    println!("Test passed");
 }

--- a/tests/cleanup_all.sh
+++ b/tests/cleanup_all.sh
@@ -19,28 +19,5 @@
 
 set -xe
 
-# Include base script
-source setup.sh
-
-# Copy TA and host binary
-cp ../examples/hello_world-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
-cp ../examples/hello_world-rs/host/target/aarch64-unknown-linux-gnu/release/hello_world-rs shared
-
-# Run script specific commands in QEMU
-run_in_qemu "cp *.ta /lib/optee_armtz/\n"
-run_in_qemu "./hello_world-rs\n"
-run_in_qemu "^C"
-
-# Script specific checks
-{
-    grep -q "original value is 29" screenlog.0 &&
-    grep -q "inc value is 129" screenlog.0 &&
-    grep -q "dec value is 29" screenlog.0 &&
-    grep -q "Success" screenlog.0
-} || {
-    cat -v screenlog.0
-    cat -v /tmp/serial.log
-    false
-}
-
-rm screenlog.0
+rm -rf screenlog.0 shared
+rm -rf optee-qemuv8-*

--- a/tests/optee-qemuv8.sh
+++ b/tests/optee-qemuv8.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cd optee-qemuv8-3.20.0-ubuntu-20.04 && ./qemu-system-aarch64 \
+cd $1 && ./qemu-system-aarch64 \
     -nodefaults \
     -nographic \
     -serial stdio -serial file:/tmp/serial.log \
@@ -30,6 +30,4 @@ cd optee-qemuv8-3.20.0-ubuntu-20.04 && ./qemu-system-aarch64 \
     -append 'console=ttyAMA0,38400 keep_bootcon root=/dev/vda2' \
     -kernel Image -no-acpi \
     -fsdev local,id=fsdev0,path=$(pwd)/../shared,security_model=none \
-    -device virtio-9p-device,fsdev=fsdev0,mount_tag=host \
-    -netdev user,id=vmnic,hostfwd=:127.0.0.1:54433-:4433 \
-    -device virtio-net-device,netdev=vmnic
+    -device virtio-9p-device,fsdev=fsdev0,mount_tag=host 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -xe
+
+# Default value for NEED_EXPANDED_MEM
+: ${NEED_EXPANDED_MEM:=false}
+
+# Define IMG_VERSION
+IMG_VERSION="optee-qemuv8-4.2.0-ubuntu-24.04"
+
+# Set IMG based on NEED_EXPANDED_MEM
+if [ "$NEED_EXPANDED_MEM" = true ]; then
+    IMG="${IMG_VERSION}-expand-ta-memory"
+else
+    IMG="$IMG_VERSION"
+fi
+
+# Function to download image
+download_image() {
+    curl "https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/${IMG}.tar.gz" | tar zxv
+}
+
+# Functions for running commands in QEMU screen
+run_in_qemu() {
+    screen -S qemu_screen -p 0 -X stuff "$1\n"
+    sleep 5
+}
+
+# Check if the image file exists locally
+if [ ! -d "${IMG}" ]; then
+    echo "Image file '${IMG}' not found locally. Downloading from network."
+    download_image
+else
+    echo "Image file '${IMG}' found locally."
+fi
+
+mkdir -p shared
+
+# Start QEMU screen
+screen -L -d -m -S qemu_screen ./optee-qemuv8.sh $IMG
+sleep 30
+run_in_qemu "root"
+run_in_qemu "mkdir -p shared && mount -t 9p -o trans=virtio host shared && cd shared"
+# libteec.so.2 since OP-TEE 4.2.0, for legacy versions:
+run_in_qemu "[ ! -e /usr/lib/libteec.so.1 ] && ln -s /usr/lib/libteec.so /usr/lib/libteec.so.1"

--- a/tests/test_aes.sh
+++ b/tests/test_aes.sh
@@ -19,41 +19,30 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/aes-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/aes-rs/host/target/aarch64-unknown-linux-gnu/release/aes-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./aes-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./aes-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Prepare encode operation" screenlog.0 &&
-	grep -q "Load key in TA" screenlog.0 &&
-	grep -q "Reset ciphering operation in TA (provides the initial vector)" screenlog.0 &&
-	grep -q "Encode buffer from TA" screenlog.0 &&
-	grep -q "Prepare decode operation" screenlog.0 &&
-	grep -q "Clear text and decoded text match" screenlog.0
+    grep -q "Prepare encode operation" screenlog.0 &&
+    grep -q "Load key in TA" screenlog.0 &&
+    grep -q "Reset ciphering operation in TA (provides the initial vector)" screenlog.0 &&
+    grep -q "Encode buffer from TA" screenlog.0 &&
+    grep -q "Prepare decode operation" screenlog.0 &&
+    grep -q "Clear text and decoded text match" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
-	false
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
+    false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_authentication.sh
+++ b/tests/test_authentication.sh
@@ -19,37 +19,26 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/authentication-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/authentication-rs/host/target/aarch64-unknown-linux-gnu/release/authentication-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./authentication-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./authentication-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Clear text and decoded text match" screenlog.0 &&
-	grep -q "Success" screenlog.0
+    grep -q "Clear text and decoded text match" screenlog.0 &&
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_big_int.sh
+++ b/tests/test_big_int.sh
@@ -19,44 +19,33 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/big_int-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/big_int-rs/host/target/aarch64-unknown-linux-gnu/release/big_int-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./big_int-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./big_int-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "\[.*] > \[.*]\|\[.*] < \[.*]\|\[.*] == \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] in u8 array is \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] in i32 is [0-9]*" /tmp/serial.log &&
-	grep -q "\[.*] + \[.*] = \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] - \[.*] = \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] \* \[.*] = \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] / \[.*] = \[.*]" /tmp/serial.log &&
-	grep -q "\[.*] % \[.*] = \[.*]" /tmp/serial.log &&
-	grep -q "Success" screenlog.0
+    grep -q "\[.*] > \[.*]\|\[.*] < \[.*]\|\[.*] == \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] in u8 array is \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] in i32 is [0-9]*" /tmp/serial.log &&
+    grep -q "\[.*] + \[.*] = \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] - \[.*] = \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] \* \[.*] = \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] / \[.*] = \[.*]" /tmp/serial.log &&
+    grep -q "\[.*] % \[.*] = \[.*]" /tmp/serial.log &&
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_diffie_hellman.sh
+++ b/tests/test_diffie_hellman.sh
@@ -19,38 +19,27 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/diffie_hellman-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/diffie_hellman-rs/host/target/aarch64-unknown-linux-gnu/release/diffie_hellman-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./diffie_hellman-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./diffie_hellman-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "get key [0|1] pair as public: \[.*], private: \[.*]" screenlog.0 &&
-	grep -q "Derived share key as \[.*]" screenlog.0 &&
-	grep -q "Success" screenlog.0
+    grep -q "get key [0|1] pair as public: \[.*], private: \[.*]" screenlog.0 &&
+    grep -q "Derived share key as \[.*]" screenlog.0 &&
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_digest.sh
+++ b/tests/test_digest.sh
@@ -19,37 +19,26 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/digest-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/digest-rs/host/target/aarch64-unknown-linux-gnu/release/digest-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./digest-rs message1 message2\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./digest-rs message1 message2\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Get message hash as:" screenlog.0 &&
-	grep -q "Success" screenlog.0
+    grep -q "Get message hash as:" screenlog.0 &&
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_error_handling.sh
+++ b/tests/test_error_handling.sh
@@ -19,36 +19,26 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/error_handling-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/error_handling-rs/host/target/aarch64-unknown-linux-gnu/release/error_handling-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./error_handling-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./error_handling-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q -v "panicked" screenlog.0
+    grep -q -v "panicked" screenlog.0 &&
+    grep -q "Test passed" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
-	false
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
+    false
 }
 
 rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared

--- a/tests/test_random.sh
+++ b/tests/test_random.sh
@@ -19,38 +19,27 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/random-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/random-rs/host/target/aarch64-unknown-linux-gnu/release/random-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./random-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./random-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Invoking TA to generate random UUID" screenlog.0 &&
-	grep -q "Generate random UUID: [a-z0-9]*-[a-z0-9]*-[a-z0-9]*-[a-z0-9]*" screenlog.0 &&
-	grep -q "Success" screenlog.0
+    grep -q "Invoking TA to generate random UUID" screenlog.0 &&
+    grep -q "Generate random UUID: [a-z0-9]*-[a-z0-9]*-[a-z0-9]*-[a-z0-9]*" screenlog.0 &&
+    grep -q "Success" screenlog.0
 } || {
         cat -v screenlog.0
         cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_secure_storage.sh
+++ b/tests/test_secure_storage.sh
@@ -19,46 +19,35 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/secure_storage-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/secure_storage-rs/host/target/aarch64-unknown-linux-gnu/release/secure_storage-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./secure_storage-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./secure_storage-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Test on object \"object#1\"" screenlog.0 &&
-	grep -q "\- Create and load object in the TA secure storage" screenlog.0 &&
-	grep -q "\- Read back the object" screenlog.0 &&
-	grep -q "\- Content read-out correctly" screenlog.0 &&
-	grep -q "\- Delete the object" screenlog.0 &&
+    grep -q "Test on object \"object#1\"" screenlog.0 &&
+    grep -q "\- Create and load object in the TA secure storage" screenlog.0 &&
+    grep -q "\- Read back the object" screenlog.0 &&
+    grep -q "\- Content read-out correctly" screenlog.0 &&
+    grep -q "\- Delete the object" screenlog.0 &&
 
-	grep -q "Test on object \"object#2\"" screenlog.0 &&
-	#miss the read correctly output
-	grep -Eq "\- Object not found in TA secure storage, create it|\- Object found in TA secure storage, delete it" screenlog.0 &&
+    grep -q "Test on object \"object#2\"" screenlog.0 &&
+    #miss the read correctly output
+    grep -Eq "\- Object not found in TA secure storage, create it|\- Object found in TA secure storage, delete it" screenlog.0 &&
 
-	grep -q "We're done, close and release TEE resources" screenlog.0
+    grep -q "We're done, close and release TEE resources" screenlog.0
 } || {
         cat -v screenlog.0
         cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_signature_verification.sh
+++ b/tests/test_signature_verification.sh
@@ -19,36 +19,25 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/signature_verification-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/signature_verification-rs/host/target/aarch64-unknown-linux-gnu/release/signature_verification-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./signature_verification-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./signature_verification-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Success" screenlog.0
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
-	false
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
+    false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_supp_plugin.sh
+++ b/tests/test_supp_plugin.sh
@@ -19,47 +19,33 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/supp_plugin-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/supp_plugin-rs/host/target/aarch64-unknown-linux-gnu/release/supp_plugin-rs shared
 cp ../examples/supp_plugin-rs/plugin/target/aarch64-unknown-linux-gnu/release/*.plugin.so shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.plugin.so /usr/lib/tee-supplicant/plugins/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "kill \$(pidof tee-supplicant)\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "/usr/sbin/tee-supplicant &\n\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./supp_plugin-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "cp *.plugin.so /usr/lib/tee-supplicant/plugins/\n"
+run_in_qemu "kill \$(pidof tee-supplicant)\n"
+run_in_qemu "/usr/sbin/tee-supplicant &\n\n"
+run_in_qemu "./supp_plugin-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "send value" screenlog.0 &&
-	grep -q "invoke" screenlog.0 &&
-	grep -q "receive value" screenlog.0 &&
-	grep -q "invoke commmand finished" screenlog.0 &&
-	grep -q "Success" screenlog.0
+    grep -q "send value" screenlog.0 &&
+    grep -q "invoke" screenlog.0 &&
+    grep -q "receive value" screenlog.0 &&
+    grep -q "invoke commmand finished" screenlog.0 &&
+    grep -q "Success" screenlog.0
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
-	false
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
+    false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0

--- a/tests/test_time.sh
+++ b/tests/test_time.sh
@@ -19,40 +19,29 @@
 
 set -xe
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+# Include base script
+source setup.sh
 
-curl https://nightlies.apache.org/teaclave/teaclave-trustzone-sdk/optee-qemuv8-3.20.0-ubuntu-20.04.tar.gz | tar zxv
-mkdir shared
+# Copy TA and host binary
 cp ../examples/time-rs/ta/target/aarch64-unknown-linux-gnu/release/*.ta shared
 cp ../examples/time-rs/host/target/aarch64-unknown-linux-gnu/release/time-rs shared
 
-screen -L -d -m -S qemu_screen ./optee-qemuv8.sh
-sleep 30
-screen -S qemu_screen -p 0 -X stuff "root\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "mkdir shared && mount -t 9p -o trans=virtio host shared && cd shared\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "cp *.ta /lib/optee_armtz/\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "./time-rs\n"
-sleep 5
-screen -S qemu_screen -p 0 -X stuff "^C"
-sleep 5
+# Run script specific commands in QEMU
+run_in_qemu "cp *.ta /lib/optee_armtz/\n"
+run_in_qemu "./time-rs\n"
+run_in_qemu "^C"
 
+# Script specific checks
 {
-	grep -q "Success" screenlog.0 &&
-	grep -q "\[+] Get REE time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log &&
-	grep -q "\[+] Now wait 1 second in TEE" /tmp/serial.log &&
-	grep -q "\[+] Get system time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log &&
-	grep -q "\[+] After set the TA time 5 seconds ahead of system time, new TA time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log
+    grep -q "Success" screenlog.0 &&
+    grep -q "\[+] Get REE time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log &&
+    grep -q "\[+] Now wait 1 second in TEE" /tmp/serial.log &&
+    grep -q "\[+] Get system time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log &&
+    grep -q "\[+] After set the TA time 5 seconds ahead of system time, new TA time (second: [0-9]*, millisecond: [0-9]*)" /tmp/serial.log
 } || {
-	cat -v screenlog.0
-	cat -v /tmp/serial.log
+    cat -v screenlog.0
+    cat -v /tmp/serial.log
         false
 }
 
-rm -rf screenlog.0
-rm -rf optee-qemuv8-3.20.0-ubuntu-20.04
-rm -rf shared
+rm screenlog.0


### PR DESCRIPTION
- Use the OP-TEE 4.2.0 prebuilt images and avoid multiple downloads;
- Add `tests/setup.sh` for common operations;
- Add `error_handling` test in qemu ci;
- unify scripts' indentation.

Similar changes on master branch: [1].

[1] https://github.com/apache/incubator-teaclave-trustzone-sdk/commit/b05173f3ad3274b361b089896d0f51aa74ee6dd4