### PR TITLE
optee-utee: make panic_handler optional in no-std by adding "no_panic_handler" feature flag

### DIFF
--- a/optee-utee/Cargo.toml
+++ b/optee-utee/Cargo.toml
@@ -28,6 +28,7 @@ edition = "2018"
 default = ["std", "sys_std"]
 std = []
 sys_std = ["optee-utee-sys/std"]
+no_panic_handler = []
 
 [dependencies]
 optee-utee-sys = { path = "optee-utee-sys", default-features = false }

--- a/optee-utee/src/lib.rs
+++ b/optee-utee/src/lib.rs
@@ -33,6 +33,7 @@ use core::panic::PanicInfo;
 use optee_utee_sys as raw;
 
 #[cfg(not(feature = "std"))]
+#[cfg(not(feature = "no_panic_handler"))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { raw::TEE_Panic(0); }


### PR DESCRIPTION
This PR is going to provide a feature flag no_panic_handler, which allow to disable the default panic_handler optee_utee provided, and let the TA developer develop their own one.
Relative issue is here: #145 