### PR TITLE
no-std: optee-utee: make panic_handler optional

### DIFF
--- a/optee-utee/Cargo.toml
+++ b/optee-utee/Cargo.toml
@@ -32,5 +32,8 @@ uuid = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 libc_alloc = "=1.0.5"
 
+[features]
+no_panic_handler = []
+
 [workspace]
 members = ['systest']

--- a/optee-utee/src/lib.rs
+++ b/optee-utee/src/lib.rs
@@ -34,7 +34,7 @@ use core::panic::PanicInfo;
 #[cfg(not(target_os = "optee"))]
 use optee_utee_sys as raw;
 
-#[cfg(not(target_os = "optee"))]
+#[cfg(all(not(target_os = "optee"), not(feature = "no_panic_handler")))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { raw::TEE_Panic(0); }


### PR DESCRIPTION
Make panic_handler optional for no-std TAs by adding "no_panic_handler" feature flag. It allows no-std TAs to have a custom panic handler.
Relative issue is here: #145 

This PR is a recreate one, the former PR was closed due to using the wrong branch(as metioned in #143 , the only maintenance branch should be main.