### PR TITLE
Change the output formation of ToString method of Uuid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
           export OPTEE_DIR=$HOME
           source environment
 
+          # Run unit tests
+          (cd optee-utee && SYS_BUILD_TYPE=unit_test cargo test --lib --features no_panic_handler -vv)
+          (cd optee-teec && SYS_BUILD_TYPE=unit_test cargo test --lib -vv)
+
           # Build Rust optee-utee and optee-teec
           (cd optee-utee && cargo build --target aarch64-unknown-linux-gnu -vv)
           (cd optee-teec && cargo build --target aarch64-unknown-linux-gnu -vv)

--- a/optee-teec/optee-teec-sys/build.rs
+++ b/optee-teec/optee-teec-sys/build.rs
@@ -19,6 +19,21 @@ use std::env;
 use std::path::Path;
 
 fn main() {
+    const ENV_SYS_BUILD_TYPE: &str = "SYS_BUILD_TYPE";
+    println!("cargo:rerun-if-env-changed={}", ENV_SYS_BUILD_TYPE);
+
+    let build_type = env::var(ENV_SYS_BUILD_TYPE).unwrap_or(String::from("")).to_lowercase();
+    match build_type.as_str() {
+        "unit_test" => unit_test_build(),
+        _ => production_build(),
+    }
+}
+
+// this allow developers to run unit tests in host machine(even x86)
+fn unit_test_build() {
+}
+
+fn production_build() {
     let optee_client_dir = env::var("OPTEE_CLIENT_EXPORT").expect("OPTEE_CLIENT_EXPORT is not set");
     let search_path = Path::new(&optee_client_dir).join("usr/lib");
     println!("cargo:rustc-link-search={}", search_path.display());

--- a/optee-teec/src/uuid.rs
+++ b/optee-teec/src/uuid.rs
@@ -106,11 +106,32 @@ impl fmt::Display for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{:x}-{:x}-{:x}-{}",
+            "{:08x}-{:04x}-{:04x}-{}-{}",
             self.raw.timeLow,
             self.raw.timeMid,
             self.raw.timeHiAndVersion,
-            hex::encode(self.raw.clockSeqAndNode)
+            hex::encode(&self.raw.clockSeqAndNode[0..2]),
+            hex::encode(&self.raw.clockSeqAndNode[2..8]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Uuid;
+
+    #[test]
+    fn test_to_string() {
+        let uuids = [
+            "00173366-2aca-49bc-beb7-10c975e6131e", // uuid with timeLow leading zeros
+            "11173366-0aca-49bc-beb7-10c975e6131e", // uuid with timeMid leading zeros
+            "11173366-2aca-09bc-beb7-10c975e6131e", // uuid with timeHiAndVersion leading zeros
+            "11173366-2aca-19bc-beb7-10c975e6131e", // random uuid
+        ];
+        for origin in uuids.iter() {
+            let uuid = Uuid::parse_str(origin).unwrap();
+            let formatted = uuid.to_string();
+            assert_eq!(origin, &formatted);
+        }
     }
 }

--- a/optee-utee/optee-utee-sys/build.rs
+++ b/optee-utee/optee-utee-sys/build.rs
@@ -19,6 +19,22 @@ use std::env;
 use std::path::Path;
 
 fn main() {
+    const ENV_SYS_BUILD_TYPE: &str = "SYS_BUILD_TYPE";
+    println!("cargo:rerun-if-env-changed={}", ENV_SYS_BUILD_TYPE);
+
+    let build_type = env::var(ENV_SYS_BUILD_TYPE).unwrap_or(String::from("")).to_lowercase();
+    match build_type.as_str() {
+        "unit_test" => unit_test_build(),
+        _ => production_build(),
+    }
+}
+
+// this allow developers to run unit tests in host machine by
+// SYS_BUILD_TYPE=unit_test cargo test --lib --features no_panic_handler
+fn unit_test_build() {
+}
+
+fn production_build() {
     let optee_os_dir = env::var("TA_DEV_KIT_DIR").unwrap();
     let search_path = Path::new(&optee_os_dir).join("lib");
 

--- a/optee-utee/src/uuid.rs
+++ b/optee-utee/src/uuid.rs
@@ -105,11 +105,34 @@ impl fmt::Display for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{:x}-{:x}-{:x}-{}",
+            "{:08x}-{:04x}-{:04x}-{}-{}",
             self.raw.timeLow,
             self.raw.timeMid,
             self.raw.timeHiAndVersion,
-            hex::encode(self.raw.clockSeqAndNode)
+            hex::encode(&self.raw.clockSeqAndNode[0..2]),
+            hex::encode(&self.raw.clockSeqAndNode[2..8]),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn test_to_string() {
+        let uuids = [
+            "00173366-2aca-49bc-beb7-10c975e6131e", // uuid with timeLow leading zeros
+            "11173366-0aca-49bc-beb7-10c975e6131e", // uuid with timeMid leading zeros
+            "11173366-2aca-09bc-beb7-10c975e6131e", // uuid with timeHiAndVersion leading zeros
+            "11173366-2aca-19bc-beb7-10c975e6131e", // random uuid
+        ];
+        for origin in uuids.iter() {
+            let uuid = Uuid::parse_str(origin).unwrap();
+            let formatted = uuid.to_string();
+            assert_eq!(origin, &formatted);
+        }
     }
 }


### PR DESCRIPTION
1) change the realization of Display trait of Uuid, make its formation
   const of 36 bytes.
2) introduce an env(RUN_TEST_IN_REE) in optee-utee-sys crate so that
   we can run library tests of optee-utee

This one relates to #151 