### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/examples/acipher-rs/host/Cargo.toml
+++ b/examples/acipher-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "acipher-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/acipher-rs/proto/Cargo.toml
+++ b/examples/acipher-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/acipher-rs/ta/Cargo.toml
+++ b/examples/acipher-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/aes-rs/host/Cargo.toml
+++ b/examples/aes-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "aes-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/aes-rs/proto/Cargo.toml
+++ b/examples/aes-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/aes-rs/ta/Cargo.toml
+++ b/examples/aes-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/authentication-rs/host/Cargo.toml
+++ b/examples/authentication-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "authentication-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/authentication-rs/proto/Cargo.toml
+++ b/examples/authentication-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/authentication-rs/ta/Cargo.toml
+++ b/examples/authentication-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/big_int-rs/host/Cargo.toml
+++ b/examples/big_int-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "big_int-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/big_int-rs/proto/Cargo.toml
+++ b/examples/big_int-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/big_int-rs/ta/Cargo.toml
+++ b/examples/big_int-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/diffie_hellman-rs/host/Cargo.toml
+++ b/examples/diffie_hellman-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "diffie_hellman-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/diffie_hellman-rs/proto/Cargo.toml
+++ b/examples/diffie_hellman-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/diffie_hellman-rs/ta/Cargo.toml
+++ b/examples/diffie_hellman-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/digest-rs/host/Cargo.toml
+++ b/examples/digest-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "digest-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/digest-rs/proto/Cargo.toml
+++ b/examples/digest-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/digest-rs/ta/Cargo.toml
+++ b/examples/digest-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/error_handling-rs/host/Cargo.toml
+++ b/examples/error_handling-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "error_handling-rs"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/error_handling-rs/proto/Cargo.toml
+++ b/examples/error_handling-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/error_handling-rs/ta/Cargo.toml
+++ b/examples/error_handling-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hello_world-rs/host/Cargo.toml
+++ b/examples/hello_world-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "hello_world-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hello_world-rs/proto/Cargo.toml
+++ b/examples/hello_world-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hello_world-rs/ta/Cargo.toml
+++ b/examples/hello_world-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hotp-rs/host/Cargo.toml
+++ b/examples/hotp-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "hotp-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hotp-rs/proto/Cargo.toml
+++ b/examples/hotp-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/hotp-rs/ta/Cargo.toml
+++ b/examples/hotp-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/message_passing_interface-rs/host/Cargo.toml
+++ b/examples/message_passing_interface-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "message_passing_interface-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/message_passing_interface-rs/proto/Cargo.toml
+++ b/examples/message_passing_interface-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/message_passing_interface-rs/ta/Cargo.toml
+++ b/examples/message_passing_interface-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/random-rs/host/Cargo.toml
+++ b/examples/random-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "random-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/random-rs/proto/Cargo.toml
+++ b/examples/random-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/random-rs/ta/Cargo.toml
+++ b/examples/random-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/secure_storage-rs/host/Cargo.toml
+++ b/examples/secure_storage-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "secure_storage-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/secure_storage-rs/proto/Cargo.toml
+++ b/examples/secure_storage-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/secure_storage-rs/ta/Cargo.toml
+++ b/examples/secure_storage-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/serde-rs/host/Cargo.toml
+++ b/examples/serde-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "serde-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/serde-rs/proto/Cargo.toml
+++ b/examples/serde-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/serde-rs/ta/Cargo.toml
+++ b/examples/serde-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/signature_verification-rs/host/Cargo.toml
+++ b/examples/signature_verification-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "signature_verification-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/signature_verification-rs/proto/Cargo.toml
+++ b/examples/signature_verification-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/signature_verification-rs/ta/Cargo.toml
+++ b/examples/signature_verification-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/supp_plugin-rs/host/Cargo.toml
+++ b/examples/supp_plugin-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "supp_plugin-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/supp_plugin-rs/plugin/Cargo.toml
+++ b/examples/supp_plugin-rs/plugin/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "syslog_plugin"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/supp_plugin-rs/proto/Cargo.toml
+++ b/examples/supp_plugin-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/supp_plugin-rs/ta/Cargo.toml
+++ b/examples/supp_plugin-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tcp_client-rs/host/Cargo.toml
+++ b/examples/tcp_client-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "tcp_client-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tcp_client-rs/proto/Cargo.toml
+++ b/examples/tcp_client-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tcp_client-rs/ta/Cargo.toml
+++ b/examples/tcp_client-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/time-rs/host/Cargo.toml
+++ b/examples/time-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "time-rs"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/time-rs/proto/Cargo.toml
+++ b/examples/time-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/time-rs/ta/Cargo.toml
+++ b/examples/time-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_client-rs/host/Cargo.toml
+++ b/examples/tls_client-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "tls_client-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_client-rs/proto/Cargo.toml
+++ b/examples/tls_client-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_client-rs/ta/Cargo.toml
+++ b/examples/tls_client-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_server-rs/host/Cargo.toml
+++ b/examples/tls_server-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "tls_server-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_server-rs/proto/Cargo.toml
+++ b/examples/tls_server-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/tls_server-rs/ta/Cargo.toml
+++ b/examples/tls_server-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/udp_socket-rs/host/Cargo.toml
+++ b/examples/udp_socket-rs/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "udp_socket-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/udp_socket-rs/proto/Cargo.toml
+++ b/examples/udp_socket-rs/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/examples/udp_socket-rs/ta/Cargo.toml
+++ b/examples/udp_socket-rs/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-teec/Cargo.toml
+++ b/optee-teec/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
@@ -25,8 +25,8 @@ description = "TEE client API."
 edition = "2018"
 
 [dependencies]
-optee-teec-sys = { version = "0.2.0", path = "optee-teec-sys" }
-optee-teec-macros = { version = "0.2.0", path = "macros" }
+optee-teec-sys = { version = "0.4.0", path = "optee-teec-sys" }
+optee-teec-macros = { version = "0.4.0", path = "macros" }
 libc = "0.2"
 uuid = "0.7"
 hex = "0.3"

--- a/optee-teec/macros/Cargo.toml
+++ b/optee-teec/macros/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec-macros"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-teec/optee-teec-sys/Cargo.toml
+++ b/optee-teec/optee-teec-sys/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec-sys"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-teec/systest/Cargo.toml
+++ b/optee-teec/systest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "systest"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee-build/Cargo.toml
+++ b/optee-utee-build/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-build"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/Cargo.toml
+++ b/optee-utee/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
@@ -25,8 +25,8 @@ description = "TEE internal core API."
 edition = "2018"
 
 [dependencies]
-optee-utee-sys = { version = "0.2.0", path = "optee-utee-sys" }
-optee-utee-macros = { version = "0.2.0", path = "macros" }
+optee-utee-sys = { version = "0.4.0", path = "optee-utee-sys" }
+optee-utee-macros = { version = "0.4.0", path = "macros" }
 bitflags = "1.0.4"
 uuid = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/optee-utee/macros/Cargo.toml
+++ b/optee-utee/macros/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-macros"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/optee-utee-sys/Cargo.toml
+++ b/optee-utee/optee-utee-sys/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-sys"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/systest/Cargo.toml
+++ b/optee-utee/systest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "systest"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/projects/web3/eth_wallet/host/Cargo.toml
+++ b/projects/web3/eth_wallet/host/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "eth_wallet-rs"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/projects/web3/eth_wallet/proto/Cargo.toml
+++ b/projects/web3/eth_wallet/proto/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/projects/web3/eth_wallet/ta/Cargo.toml
+++ b/projects/web3/eth_wallet/ta/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "ta"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"


### PR DESCRIPTION
Since there have been code changes in OP-TEE crates, examples, and projects since the previous release, we are bumping all versions to 0.4.0.