### PR TITLE
optee_teec: extension: fix macro errors

### DIFF
--- a/examples/supp_plugin-rs/host/src/main.rs
+++ b/examples/supp_plugin-rs/host/src/main.rs
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use optee_teec::{Context, Operation, ParamTmpRef, Session, Uuid};
-use optee_teec::{ParamNone};
-use proto::{TA_UUID, Command};
+use optee_teec::{Context, ErrorKind, Operation, ParamNone, ParamTmpRef, Session, Uuid};
+use proto::{Command, TA_UUID};
 
 fn ping_ta(session: &mut Session) -> optee_teec::Result<()> {
     let test_data = [0x36u8; 10];
@@ -34,7 +33,10 @@ fn ping_ta(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(TA_UUID).unwrap();
+    let uuid = Uuid::parse_str(TA_UUID).map_err(|err| {
+        println!("Invalid TA_UUID: {:?}", err);
+        ErrorKind::BadParameters
+    })?;
     let mut session = ctx.open_session(uuid)?;
 
     ping_ta(&mut session)?;

--- a/examples/supp_plugin-rs/plugin/Cargo.toml
+++ b/examples/supp_plugin-rs/plugin/Cargo.toml
@@ -28,9 +28,8 @@ edition = "2018"
 libc = "0.2.48"
 proto = { path = "../proto" }
 optee-teec = { path = "../../../optee-teec" }
-optee-teec-sys = { path = "../../../optee-teec/optee-teec-sys" }
 
-[build_dependencies]
+[build-dependencies]
 uuid = { version = "0.8" }
 proto = { path = "../proto" }
 

--- a/examples/supp_plugin-rs/plugin/build.rs
+++ b/examples/supp_plugin-rs/plugin/build.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
 use std::env;
 use std::fs::File;
 use std::io::Write;
-use std::path::{PathBuf};
+use std::path::PathBuf;
 use uuid::Uuid;
 
 fn main() -> std::io::Result<()> {
@@ -33,7 +32,7 @@ fn main() -> std::io::Result<()> {
     write!(buffer, "\n")?;
     write!(
         buffer,
-        "const PLUGIN_UUID_STRUCT: optee_teec_sys::TEEC_UUID = optee_teec_sys::TEEC_UUID {{
+        "const PLUGIN_UUID_STRUCT: optee_teec::raw::TEEC_UUID = optee_teec::raw::TEEC_UUID {{
     timeLow: {:#x},
     timeMid: {:#x},
     timeHiAndVersion: {:#x},

--- a/examples/supp_plugin-rs/plugin/plugin_static.rs
+++ b/examples/supp_plugin-rs/plugin/plugin_static.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 #[no_mangle]
-pub static mut plugin_method: PluginMethod = PluginMethod {
-    name: plugin_name.as_ptr() as *const c_char,
+pub static mut plugin_method: optee_teec::PluginMethod = optee_teec::PluginMethod {
+    name: plugin_name.as_ptr(),
     uuid: PLUGIN_UUID_STRUCT,
     init: _plugin_init,
     invoke: _plugin_invoke,

--- a/examples/supp_plugin-rs/proto/src/lib.rs
+++ b/examples/supp_plugin-rs/proto/src/lib.rs
@@ -27,7 +27,7 @@ pub enum Command {
 }
 
 // If Uuid::parse_str() returns an InvalidLength error, there may be an extra
-// newline in your uuid.txt file. You can remove it by running 
+// newline in your uuid.txt file. You can remove it by running
 // `truncate -s 36 ta_uuid.txt`.
 pub const TA_UUID: &str = &include_str!("../../ta_uuid.txt");
 
@@ -42,6 +42,6 @@ pub enum PluginCommand {
 
 pub const PLUGIN_SUBCMD_NULL: u32 = 0xFFFFFFFF;
 // If Uuid::parse_str() returns an InvalidLength error, there may be an extra
-// newline in your uuid.txt file. You can remove it by running 
+// newline in your uuid.txt file. You can remove it by running
 // `truncate -s 36 plugin_uuid.txt`.
 pub const PLUGIN_UUID: &str = &include_str!("../../plugin_uuid.txt");

--- a/examples/supp_plugin-rs/ta/build.rs
+++ b/examples/supp_plugin-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::TA_UUID)?;

--- a/optee-teec/macros/Cargo.toml
+++ b/optee-teec/macros/Cargo.toml
@@ -28,8 +28,8 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quote = "0.6"
-syn = { version = "0.15", features = ["full"] }
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
 
 # The newer versions of these crates require rustc 1.81, while our custom
 # patched STD version is 1.80, causing compatibility issues. To resolve this,

--- a/optee-teec/src/context.rs
+++ b/optee-teec/src/context.rs
@@ -15,10 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{Error, Operation, Result, Session, Uuid};
-use crate::{Param, ParamNone};
+use crate::{raw, Error, Operation, Param, ParamNone, Result, Session, Uuid};
 use libc;
-use optee_teec_sys as raw;
 use std::ptr;
 
 /// An abstraction of the logical connection between a client application and a
@@ -44,7 +42,7 @@ impl Context {
     /// # Examples
     ///
     /// ```
-    /// let raw_ctx: optee_teec_sys::TEEC_Context = Context::new_raw(0, true).unwrap();
+    /// let raw_ctx: optee_teec::raw::TEEC_Context = Context::new_raw(0, true).unwrap();
     /// ```
     pub fn new_raw(fd: libc::c_int, reg_mem: bool, memref_null: bool) -> Result<raw::TEEC_Context> {
         let mut raw_ctx = raw::TEEC_Context {
@@ -66,7 +64,7 @@ impl Context {
     ///
     /// ```
     /// let mut ctx = Context::new().unwrap();
-    /// let mut raw_ptr: *mut optee_teec_sys::TEEC_Context = ctx.as_mut_raw_ptr();
+    /// let mut raw_ptr: *mut optee_teec::raw::TEEC_Context = ctx.as_mut_raw_ptr();
     /// ```
     pub fn as_mut_raw_ptr(&mut self) -> *mut raw::TEEC_Context {
         &mut self.raw

--- a/optee-teec/src/error.rs
+++ b/optee-teec/src/error.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use optee_teec_sys as raw;
+use crate::raw;
 use std::fmt;
 
 /// A specialized [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)

--- a/optee-teec/src/extension.rs
+++ b/optee-teec/src/extension.rs
@@ -15,22 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use optee_teec_sys as raw;
-use libc::{c_char};
-use crate::{Result, Error, ErrorKind};
+use crate::raw;
+use crate::{Error, ErrorKind, Result};
+use libc::c_char;
 
 #[repr(C)]
 pub struct PluginMethod {
     pub name: *const c_char,
     pub uuid: raw::TEEC_UUID,
-    pub init: fn() -> Result<()>,
+    pub init: fn() -> raw::TEEC_Result,
     pub invoke: fn(
         cmd: u32,
         sub_cmd: u32,
         data: *mut c_char,
         in_len: u32,
         out_len: *mut u32,
-    ) -> Result<()>,
+    ) -> raw::TEEC_Result,
 }
 
 /// struct PluginParameters {

--- a/optee-teec/src/lib.rs
+++ b/optee-teec/src/lib.rs
@@ -23,6 +23,9 @@ pub use self::session::{ConnectionMethods, Session};
 pub use self::uuid::Uuid;
 pub use self::extension::*;
 pub use optee_teec_macros::{plugin_init, plugin_invoke};
+// Re-export optee_teec_sys so developers don't have to add it to their cargo
+// dependencies.
+pub use optee_teec_sys as raw;
 
 mod context;
 mod error;

--- a/optee-teec/src/operation.rs
+++ b/optee-teec/src/operation.rs
@@ -15,10 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{Param, ParamTypes};
-use optee_teec_sys as raw;
-use std::marker::PhantomData;
-use std::mem;
+use crate::{raw, Param, ParamTypes};
+use std::{marker::PhantomData, mem};
 
 /// This type defines the payload of either an open session operation or an
 /// invoke command operation. It is also used for cancellation of operations,

--- a/optee-teec/src/parameter.rs
+++ b/optee-teec/src/parameter.rs
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use optee_teec_sys as raw;
-use std::marker;
-use std::mem;
+use crate::raw;
+use std::{marker, mem};
 
 pub trait Param {
     fn into_raw(&mut self) -> raw::TEEC_Parameter;

--- a/optee-teec/src/session.rs
+++ b/optee-teec/src/session.rs
@@ -16,12 +16,10 @@
 // under the License.
 
 use libc;
-use optee_teec_sys as raw;
-use std::ptr;
 use std::marker;
+use std::ptr;
 
-use crate::Param;
-use crate::{Context, Error, Operation, Result, Uuid};
+use crate::{raw, Context, Error, Operation, Param, Result, Uuid};
 
 /// Session login methods.
 #[derive(Copy, Clone)]
@@ -72,7 +70,10 @@ impl<'ctx> Session<'ctx> {
                 raw_operation,
                 &mut err_origin,
             ) {
-                raw::TEEC_SUCCESS => Ok(Self { raw: raw_session,  _marker: marker::PhantomData }),
+                raw::TEEC_SUCCESS => Ok(Self {
+                    raw: raw_session,
+                    _marker: marker::PhantomData,
+                }),
                 code => Err(Error::from_raw_error(code)),
             }
         }

--- a/optee-teec/src/uuid.rs
+++ b/optee-teec/src/uuid.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::raw;
 use core::fmt;
 use hex;
-use optee_teec_sys as raw;
 use uuid as uuid_crate;
 use uuid_crate::parser::ParseError;
 use uuid_crate::BytesError;


### PR DESCRIPTION
1. Fix usage of Rust types as return values in FFI functions.
    https://github.com/apache/incubator-teaclave-trustzone-sdk/blob/cf0f662eec9213be32bf972888f422575b03bc7a/optee-teec/src/extension.rs#L23-L33
    Currently, the plugin's methods use Rust's `optee_teec::Result` as the return value for `FFI`, which is incorrect since Rust does not guarantee a stable ABI. We need to change them to `optee_teec_sys::TEEC_Result`(alias of u32) instead.

2. Standardize the function signature to require returning a Result.
    Similar to the original signatures of TEEC functions, we currently require the plugin's methods to return an error.
    * For `init`: from `fn()` to `fn() -> optee_teec::Result<()>`
    * For `invoke_command`: from `fn(&mut optee_teec::PluginParameters)` to `fn(&mut optee_teec::PluginParameters) -> optee_teec::Result<()>`

    And in fact, the current examples of `supp_plugin-rs` already return a Result, even though this contradicts their function signatures.
    ![image](https://github.com/user-attachments/assets/a24cbd99-edf2-4802-8359-66ef90d96eef)

3. Use inner functions in generated code to prevent unexpected early returns.
    Previous macros simply duplicated the code into the new function.
    https://github.com/apache/incubator-teaclave-trustzone-sdk/blob/cf0f662eec9213be32bf972888f422575b03bc7a/optee-teec/macros/src/lib.rs#L60-L67
    Which is buggy if developers have some return statements inside.
    For example, if developer define a function:
    ```rust
    fn init() {
        if method() {
            return;
        }
        // some other codes
    }
    ```
    It will be rewrite to:
    ```rust
    #[no_mangle]
    pub fn _plugin_init() -> optee_teec::Result<()> {
        if method() {
            return;  // this line is a syntax error
        }
        // some other codes
        Ok(())
    }
    ```

* Fix example: supp_plugin-rs.

