### PR TITLE
ci: add build_runner_image.yml

### DIFF
--- a/.github/workflows/build_runner_image.yml
+++ b/.github/workflows/build_runner_image.yml
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This action provides a standardized and reproducible way to build a CI runner
+# image.
+#
+# It is especially helpful for developers who want to contribute to the github
+# workflow of teaclave, includes the following:
+#
+# 1. Changes to the CI runner image via Dockerfile modifications
+# 2. Experiments with new platforms (e.g., adding ARM64 runner)
+#
+# Developers can build their own image, test it in their fork or repository, and
+# once verified, request maintainers to build and publish the official image.
+# The developer’s tested image and the final official image should be identical
+# to ensure consistency.
+#
+#
+# Example Workflow:
+# Suppose a developer named Alice wants to modify the base runner image.
+# She would:
+#
+# 1. Update the Dockerfile with her changes.
+# 2. Build a custom runner image using GitHub Actions.
+# 3. In her branch, temporarily replace the official runner image with her
+#    custom image in the CI workflow.
+# 4. Run the CI using the modified setup to verify everything works as expected.
+#
+# Once the tests pass:
+# 5. Alice opens a PR demonstrating the container used, the CI results.
+# 6. The Teaclave maintainers will build an official image via GitHub Actions,
+#    which should be identical to Alice's custom image.
+# 7. Finally, she updates the CI workflow to use the official image built from
+#    the updated Dockerfile instead of her custom one.
+
+
+name: Build Runner Image
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker tag'
+        required: true
+        default: 'ubuntu-24.04'
+      image_name:
+        description: 'Docker image name'
+        required: true
+        default: 'teaclave-trustzone-sdk-ci-runner'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.actor }}/${{ github.event.inputs.image_name }}
+  IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Support building runner images for both arm64 and amd64 via github ci.

This PR will allow developers to build a runner image through github actions.
![image](https://github.com/user-attachments/assets/ba9ab93b-0b1b-4ad0-b3b1-9f66915bb31a)

After the pipeline success, the runner image can be found under the developers' packages.
![image](https://github.com/user-attachments/assets/8de88e9e-b3b7-458f-a0c7-faea188152cd)

Currently we build container with two platforms: `linux/amd64`, `linux/arm64`.
![image](https://github.com/user-attachments/assets/301cfc8c-5ab0-4e53-b81f-6b9c312f100e)
