### PR TITLE
Expose login field from raw::TEEC_OpenSession

### DIFF
--- a/optee-teec/src/context.rs
+++ b/optee-teec/src/context.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{raw, Error, Operation, Param, ParamNone, Result, Session, Uuid};
+use crate::{raw, ConnectionMethods, Error, Operation, Param, ParamNone, Result, Session, Uuid};
 use std::{cell::RefCell, ptr, rc::Rc};
 
 pub struct InnerContext(pub raw::TEEC_Context);
@@ -90,6 +90,20 @@ impl Context {
         Session::new(
             self,
             uuid,
+            ConnectionMethods::LoginPublic,
+            None::<&mut Operation<ParamNone, ParamNone, ParamNone, ParamNone>>,
+        )
+    }
+
+    pub fn open_session_with_login(
+        &mut self,
+        uuid: Uuid,
+        login: ConnectionMethods,
+    ) -> Result<Session> {
+        Session::new(
+            self,
+            uuid,
+            login,
             None::<&mut Operation<ParamNone, ParamNone, ParamNone, ParamNone>>,
         )
     }
@@ -121,7 +135,7 @@ impl Context {
         uuid: Uuid,
         operation: &mut Operation<A, B, C, D>,
     ) -> Result<Session> {
-        Session::new(self, uuid, Some(operation))
+        Session::new(self, uuid, ConnectionMethods::LoginPublic, Some(operation))
     }
 }
 

--- a/optee-teec/src/session.rs
+++ b/optee-teec/src/session.rs
@@ -56,6 +56,7 @@ impl Session {
     pub fn new<A: Param, B: Param, C: Param, D: Param>(
         context: &mut Context,
         uuid: Uuid,
+        login: ConnectionMethods,
         operation: Option<&mut Operation<A, B, C, D>>,
     ) -> Result<Self> {
         // SAFETY:
@@ -78,7 +79,7 @@ impl Session {
                 raw_ctx,
                 &mut raw_session,
                 raw_uuid,
-                ConnectionMethods::LoginPublic as u32,
+                login as u32,
                 ptr::null(),
                 raw_operation,
                 &mut err_origin,


### PR DESCRIPTION
Adding a new method to open a session with login field set by caller instead of hard coding it to default (`ConnectionMethods::LoginPublic`)

Legacy constructor is not removed.