### PR TITLE
Version bump for release 0.5.0

### DIFF
--- a/build_optee_libraries.sh
+++ b/build_optee_libraries.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-OPTEE_VERSION=4.5.0
+OPTEE_VERSION=4.6.0
 OPTEE_DIR=$1
 
 # check arguments

--- a/optee-teec/Cargo.toml
+++ b/optee-teec/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
@@ -25,15 +25,15 @@ description = "TEE client API."
 edition = "2018"
 
 [dependencies]
-optee-teec-sys = { version = "0.4.0", path = "optee-teec-sys" }
-optee-teec-macros = { version = "0.4.0", path = "macros" }
+optee-teec-sys = { version = "0.5.0", path = "optee-teec-sys" }
+optee-teec-macros = { version = "0.5.0", path = "macros" }
 uuid = "0.7"
 hex = "0.3"
 num_enum = "0.7.3"
 
 [dev-dependencies]
 # disable linking when running unit tests
-optee-teec-sys = { version = "0.4.0", path = "optee-teec-sys", features = ["no_link"] }
+optee-teec-sys = { version = "0.5.0", path = "optee-teec-sys", features = ["no_link"] }
 
 [workspace]
 resolver = "2"

--- a/optee-teec/macros/Cargo.toml
+++ b/optee-teec/macros/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec-macros"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-teec/optee-teec-sys/Cargo.toml
+++ b/optee-teec/optee-teec-sys/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-teec-sys"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-teec/systest/Cargo.toml
+++ b/optee-teec/systest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "systest"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee-build/Cargo.toml
+++ b/optee-utee-build/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-build"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/Cargo.toml
+++ b/optee-utee/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"
@@ -25,8 +25,8 @@ description = "TEE internal core API."
 edition = "2018"
 
 [dependencies]
-optee-utee-sys = { version = "0.4.0", path = "optee-utee-sys" }
-optee-utee-macros = { version = "0.4.0", path = "macros" }
+optee-utee-sys = { version = "0.5.0", path = "optee-utee-sys" }
+optee-utee-macros = { version = "0.5.0", path = "macros" }
 bitflags = "1.0.4"
 uuid = { version = "0.8", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -39,7 +39,7 @@ once_cell = "1.20.2"
 serde = { version = "1.0.215" }
 serde_json = { version = "1.0.133" }
 # disable linking when running unit tests
-optee-utee-sys = { version = "0.4.0", path = "optee-utee-sys", features = ["no_link"] }
+optee-utee-sys = { version = "0.5.0", path = "optee-utee-sys", features = ["no_link"] }
 
 [features]
 no_panic_handler = []

--- a/optee-utee/macros/Cargo.toml
+++ b/optee-utee/macros/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-macros"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/optee-utee-sys/Cargo.toml
+++ b/optee-utee/optee-utee-sys/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "optee-utee-sys"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"

--- a/optee-utee/systest/Cargo.toml
+++ b/optee-utee/systest/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "systest"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Teaclave Contributors <dev@teaclave.apache.org>"]
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-teaclave-trustzone-sdk.git"


### PR DESCRIPTION
- Bump OP-TEE version to `4.6.0`
- Bump optee-* crates version to `0.5.0`