### PR TITLE
ci: add workflow to draft release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name-template: 'Apache Teaclave TrustZone SDK (incubating) v$RESOLVED_VERSION'
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - 'enhancement'
+  - title: "📚 Examples"
+    labels:
+      - "example"
+  - title: "⚙️ Refactoring"
+    labels:
+      - "refactor"
+  - title: "🔧 Build / CI"
+    labels:
+      - "build"
+      - "ci"
+  - title: "📦 Dependencies"
+    labels:
+      - "dependencies"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "📝 Documentation"
+    labels:
+      - "documentation"
+
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Draft Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Version to release (e.g., 0.5.0)'
+        required: true
+
+jobs:
+  draft_release:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ github.event.inputs.release_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use **Release Drafter** to automatically generate release notes, reducing the manual effort. You can see an example draft here:  
https://github.com/release-drafter/release-drafter?tab=readme-ov-file#example

### How to trigger the workflow

Manually trigger this workflow when release notes are needed:

1. Go to **Actions** → **Draft Release Notes**
2. Click **Run workflow**
3. Enter the **Version to release** (for example, `0.5.0`)
4. Click **Run workflow** again

After the workflow completes, a draft release will appear at:  
https://github.com/apache/incubator-teaclave-trustzone-sdk/releases

### Notes

- The release note includes all pull requests merged into `main` since **the time of previous tag created on main**.
- Pull request **labels** are used to categorize changes in the release notes. After this PR is merged, I will label the existing PRs for the next release. In the future, I recommend adding labels to each PR when it is created to ensure proper categorization.
