### PR TITLE
Simplified makefile

### DIFF
--- a/.github/workflows/reuse_test.yml
+++ b/.github/workflows/reuse_test.yml
@@ -88,25 +88,25 @@ jobs:
           export ARCH_HOST=arm
           export ARCH_TA=arm
           source environment
-          make -j`nproc`
+          make examples -j`nproc`
 
           # Build OP-TEE Rust examples for Arm 32-bit host and 64-bit TA
           export ARCH_HOST=arm
           unset ARCH_TA
           source environment
-          make clean && make -j`nproc`
+          make clean && make examples -j`nproc`
 
           # Build OP-TEE Rust examples for Arm 64-bit host and 32-bit TA
           unset ARCH_HOST
           export ARCH_TA=arm
           source environment
-          make clean && make -j`nproc`
+          make clean && make examples -j`nproc`
 
           # Build OP-TEE Rust examples for Arm 64-bit both host and TA
           unset ARCH_TA
           unset ARCH_HOST
           source environment
-          make clean && make -j`nproc`
+          make clean && make examples -j`nproc`
       - name: Run tests for Arm 64-bit both host and TA
         run: |
           source environment
@@ -137,7 +137,7 @@ jobs:
           source environment
 
           # Build OP-TEE Rust examples for Arm 64-bit both host and TA
-          make -j2
+          make std-examples -j2
 
           # Build project
           (cd projects/web3/eth_wallet && make)
@@ -173,7 +173,7 @@ jobs:
           source environment
 
           # Build OP-TEE Rust examples for Arm 64-bit both host and TA
-          make -j2
+          make std-examples -j2
 
           # Build project
           (cd projects/web3/eth_wallet && make)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ target/
 /out
 Cargo.lock
 
+rust/
+
 # Allow tracking Cargo.lock in std examples
 !examples/message_passing_interface-rs/ta/Cargo.lock
 !examples/secure_db_abstraction-rs/ta/Cargo.lock

--- a/docs/overview-of-optee-rust-examples.md
+++ b/docs/overview-of-optee-rust-examples.md
@@ -13,28 +13,28 @@ after `make examples`.
 
 To compile one of the examples, run `make -C examples/EXAMPLE_DIR`.
 
-| Host application name        | TA UUID                                | Description                                                  |
-| ---------------------------- | -------------------------------------- | ------------------------------------------------------------ |
-| acipher-rs                   | `057f4b66-bdab-11eb-96cf-33d6e41cc849` | Generate an RSA key pair,  encrypt a supplied string and decrypt it. |
-| aes-rs                       | `0864c8ec-bdab-11eb-8926-c7fa47a8c92d` | Run an AES encryption and decryption.                        |
-| authentication-rs            | `0a5a06b2-bdab-11eb-add0-77f29de31296` | Run AES-CCM authenticated encryption / decryption.           |
-| big_int-rs                   | `0bef16a2-bdab-11eb-94be-6f9815f37c21` | Do mathematical operations of big integers, such as addition, subtraction, multiplication, division, etc. |
-| diffie_hellman-rs            | `0e6bf4fe-bdab-11eb-9bc5-3f4ecb50aee7` | Run Diffie-Hellman key exchange to derive shared secrets.    |
-| digest-rs                    | `10de87e2-bdab-11eb-b73c-63fec73e597c` | Calculate the hash of the message using SHA256 digest algorithm. |
-| hello_world-rs               | `133af0ca-bdab-11eb-9130-43bf7873bf67` | Increment and decrement an integer value.                    |
-| hotp-rs                      | `1585d412-bdab-11eb-ba91-3b085fd2601f` | Generate HMAC based One Time Password which is  described in [RFC4226](https://www.ietf.org/rfc/rfc4226.txt). |
-| message_passing_interface-rs | `17556a46-bdab-11eb-b325-d38c9a9af725` | Passing serde json message between host application and TA, which is more convenient to send structured data. |
-| random-rs                    | `197c710c-bdab-11eb-8f3f-17a5f698d23b` | Generate a random UUID.                                      |
-| secure_storage-rs            | `1cd6d392-bdab-11eb-9082-abc902ac5cd4` | Read / write / delete raw data from / into the OP-TEE secure storage. |
-| serde-rs                     | `1ed47816-bdab-11eb-9ebd-3ffe0648da93` | Invoke third party crate `serde` for serialization and deserialization. |
-| supp_plugin-rs               | `255fc838-de89-42d3-9a8e-d044c50fa57c` | TA actively invokes a command defined in normal world plugins. Do interaction between host <-> TA <-> plugin. The plugin is identified by UUID: ef620757-fa2b-4f19-a1c4-6e51cfe4c0f9. |
-| tcp_client-rs                | `59db8536-e5e6-11eb-8e9b-a316ce7a6568` | Do HTTP connection from Trusted Application.                 |
-| time-rs                      | `21b1a1da-bdab-11eb-b614-275a7098826f` | Set / get TEE time.                                          |
-| udp_socket-rs                | `87c2d78e-eb7b-11eb-8d25-df4d5338f285` | Do UDP socket connection from Trusted Application.           |
-| signature_verification-rs    | `c7e478c2-89b3-46eb-ac19-571e66c3830d` | Sign a message and verify the signature using the third party crate [ring](https://github.com/veracruz-project/ring). |
-| tls_client-rs                | `ec55bfe2-d9c7-11eb-8b0e-f3f8fad927f7` | Do TLS connection from Trusted Application.                  |
-| tls_server-rs                | `69547de6-f47e-11eb-994e-f34e88d5c2b4` | Set up the TLS server in Trusted Application.                |
-| secure_db_abstraction-rs     | `e55291e1-521c-4dca-aa24-51e34ab32ad9` | An abstraction of database base on Secure Storage.           |
-| mnist-rs                     | Train: `1b5f5b74-e9cf-4e62-8c3e-7e41da6d76f6` <br/> Infer: `ff09aa8a-fbb9-4734-ae8c-d7cd1a3f6744` | Training and Performing Inference in Trusted Application. |
-| client_pool-rs               | `c9d73f40-ba45-4315-92c4-cf1255958729` | Generic Client Session Pool.                                 |
-| build_with_optee_utee_sys-rs | `bcac6292-5b9d-4b20-a2e5-b389d5e8ae2f` | Using `optee_utee_sys` as `build-dependencies`, requires `workspace.resolver = "2"`, which is not supported in xargo, so no_std only. |
+| Host application name        | TA UUID                                | Description                                                  | Std/No-std Support |
+| ---------------------------- | -------------------------------------- | ------------------------------------------------------------ | ------------------ |
+| acipher-rs                   | `057f4b66-bdab-11eb-96cf-33d6e41cc849` | Generate an RSA key pair,  encrypt a supplied string and decrypt it. | both |
+| aes-rs                       | `0864c8ec-bdab-11eb-8926-c7fa47a8c92d` | Run an AES encryption and decryption.                        | both |
+| authentication-rs            | `0a5a06b2-bdab-11eb-add0-77f29de31296` | Run AES-CCM authenticated encryption / decryption.           | both |
+| big_int-rs                   | `0bef16a2-bdab-11eb-94be-6f9815f37c21` | Do mathematical operations of big integers, such as addition, subtraction, multiplication, division, etc. | both |
+| diffie_hellman-rs            | `0e6bf4fe-bdab-11eb-9bc5-3f4ecb50aee7` | Run Diffie-Hellman key exchange to derive shared secrets.    | both |
+| digest-rs                    | `10de87e2-bdab-11eb-b73c-63fec73e597c` | Calculate the hash of the message using SHA256 digest algorithm. | both |
+| hello_world-rs               | `133af0ca-bdab-11eb-9130-43bf7873bf67` | Increment and decrement an integer value.                    | both |
+| hotp-rs                      | `1585d412-bdab-11eb-ba91-3b085fd2601f` | Generate HMAC based One Time Password which is  described in [RFC4226](https://www.ietf.org/rfc/rfc4226.txt). | both |
+| message_passing_interface-rs | `17556a46-bdab-11eb-b325-d38c9a9af725` | Passing serde json message between host application and TA, which is more convenient to send structured data. | std |
+| random-rs                    | `197c710c-bdab-11eb-8f3f-17a5f698d23b` | Generate a random UUID.                                      | both |
+| secure_storage-rs            | `1cd6d392-bdab-11eb-9082-abc902ac5cd4` | Read / write / delete raw data from / into the OP-TEE secure storage. | both |
+| serde-rs                     | `1ed47816-bdab-11eb-9ebd-3ffe0648da93` | Invoke third party crate `serde` for serialization and deserialization. | std |
+| supp_plugin-rs               | `255fc838-de89-42d3-9a8e-d044c50fa57c` | TA actively invokes a command defined in normal world plugins. Do interaction between host <-> TA <-> plugin. The plugin is identified by UUID: ef620757-fa2b-4f19-a1c4-6e51cfe4c0f9. | both |
+| tcp_client-rs                | `59db8536-e5e6-11eb-8e9b-a316ce7a6568` | Do HTTP connection from Trusted Application.                 | both |
+| time-rs                      | `21b1a1da-bdab-11eb-b614-275a7098826f` | Set / get TEE time.                                          | both |
+| udp_socket-rs                | `87c2d78e-eb7b-11eb-8d25-df4d5338f285` | Do UDP socket connection from Trusted Application.           | both |
+| signature_verification-rs    | `c7e478c2-89b3-46eb-ac19-571e66c3830d` | Sign a message and verify the signature using the third party crate [ring](https://github.com/veracruz-project/ring). | both |
+| tls_client-rs                | `ec55bfe2-d9c7-11eb-8b0e-f3f8fad927f7` | Do TLS connection from Trusted Application.                  | std |
+| tls_server-rs                | `69547de6-f47e-11eb-994e-f34e88d5c2b4` | Set up the TLS server in Trusted Application.                | std |
+| secure_db_abstraction-rs     | `e55291e1-521c-4dca-aa24-51e34ab32ad9` | An abstraction of database base on Secure Storage.           | std |
+| mnist-rs                     | Train: `1b5f5b74-e9cf-4e62-8c3e-7e41da6d76f6` <br/> Infer: `ff09aa8a-fbb9-4734-ae8c-d7cd1a3f6744` | Training and Performing Inference in Trusted Application. | no-std |
+| client_pool-rs               | `c9d73f40-ba45-4315-92c4-cf1255958729` | Generic Client Session Pool.                                 | both |
+| build_with_optee_utee_sys-rs | `bcac6292-5b9d-4b20-a2e5-b389d5e8ae2f` | Using `optee_utee_sys` as `build-dependencies`, requires `workspace.resolver = "2"`, which is not supported in xargo, so no_std only. | no-std |

--- a/docs/overview-of-optee-rust-examples.md
+++ b/docs/overview-of-optee-rust-examples.md
@@ -21,10 +21,13 @@ To compile one of the examples, run `make -C examples/EXAMPLE_DIR`.
 | big_int-rs                   | `0bef16a2-bdab-11eb-94be-6f9815f37c21` | Do mathematical operations of big integers, such as addition, subtraction, multiplication, division, etc. | both |
 | diffie_hellman-rs            | `0e6bf4fe-bdab-11eb-9bc5-3f4ecb50aee7` | Run Diffie-Hellman key exchange to derive shared secrets.    | both |
 | digest-rs                    | `10de87e2-bdab-11eb-b73c-63fec73e597c` | Calculate the hash of the message using SHA256 digest algorithm. | both |
+| error_handling-rs            | `ec59c1fc-b9e0-4c3c-8756-0a3cc48f0088` | Demonstrate error handling patterns in Trusted Applications.   | both |
 | hello_world-rs               | `133af0ca-bdab-11eb-9130-43bf7873bf67` | Increment and decrement an integer value.                    | both |
 | hotp-rs                      | `1585d412-bdab-11eb-ba91-3b085fd2601f` | Generate HMAC based One Time Password which is  described in [RFC4226](https://www.ietf.org/rfc/rfc4226.txt). | both |
+| inter_ta-rs                  | `fa9ea860-ef3b-4d59-8457-5564a60c0379` | Demonstrate inter-TA communication patterns.                   | both |
 | message_passing_interface-rs | `17556a46-bdab-11eb-b325-d38c9a9af725` | Passing serde json message between host application and TA, which is more convenient to send structured data. | std |
 | random-rs                    | `197c710c-bdab-11eb-8f3f-17a5f698d23b` | Generate a random UUID.                                      | both |
+| property-rs                  | `a3859d33-b540-4a69-8d29-696dde9115cc` | Demonstrate property-based testing in Trusted Applications.   | both |
 | secure_storage-rs            | `1cd6d392-bdab-11eb-9082-abc902ac5cd4` | Read / write / delete raw data from / into the OP-TEE secure storage. | both |
 | serde-rs                     | `1ed47816-bdab-11eb-9ebd-3ffe0648da93` | Invoke third party crate `serde` for serialization and deserialization. | std |
 | supp_plugin-rs               | `255fc838-de89-42d3-9a8e-d044c50fa57c` | TA actively invokes a command defined in normal world plugins. Do interaction between host <-> TA <-> plugin. The plugin is identified by UUID: ef620757-fa2b-4f19-a1c4-6e51cfe4c0f9. | both |

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Define example categories based on std/no-std support
+# STD-only examples (require STD=y to build)
+STD_ONLY_EXAMPLES = \
+	message_passing_interface-rs \
+	serde-rs \
+	tls_client-rs \
+	tls_server-rs \
+	secure_db_abstraction-rs
+
+# NO-STD-only examples (require STD to be unset to build)
+NO_STD_ONLY_EXAMPLES = \
+	mnist-rs \
+	build_with_optee_utee_sys-rs
+
+# Common examples (build in both std and no-std modes)
+COMMON_EXAMPLES = \
+	acipher-rs \
+	aes-rs \
+	authentication-rs \
+	big_int-rs \
+	diffie_hellman-rs \
+	digest-rs \
+	hello_world-rs \
+	hotp-rs \
+	random-rs \
+	secure_storage-rs \
+	supp_plugin-rs \
+	tcp_client-rs \
+	time-rs \
+	udp_socket-rs \
+	signature_verification-rs \
+	client_pool-rs
+
+# Clean targets
+STD_ONLY_EXAMPLES_CLEAN = $(STD_ONLY_EXAMPLES:%=%-clean)
+NO_STD_ONLY_EXAMPLES_CLEAN = $(NO_STD_ONLY_EXAMPLES:%=%-clean)
+COMMON_EXAMPLES_CLEAN = $(COMMON_EXAMPLES:%=%-clean)
+
+# Build std examples (std-only + common examples)
+std-examples: std-only-examples common-examples
+
+# Build no-std examples (no-std-only + common examples)
+no-std-examples: no-std-only-examples common-examples
+
+# Build std-only examples
+std-only-examples: $(STD_ONLY_EXAMPLES)
+
+# Build no-std-only examples
+no-std-only-examples: $(NO_STD_ONLY_EXAMPLES)
+
+# Build common examples (always built)
+common-examples: $(COMMON_EXAMPLES)
+
+# Individual example build rules
+$(STD_ONLY_EXAMPLES) $(NO_STD_ONLY_EXAMPLES) $(COMMON_EXAMPLES):
+	$(q)make -C $@ TARGET_HOST=$(TARGET_HOST) \
+		TARGET_TA=$(TARGET_TA) \
+		CROSS_COMPILE_HOST=$(CROSS_COMPILE_HOST) \
+		CROSS_COMPILE_TA=$(CROSS_COMPILE_TA) \
+		TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR) \
+		OPTEE_CLIENT_EXPORT=$(OPTEE_CLIENT_EXPORT)
+
+# Clean targets
+clean: $(STD_ONLY_EXAMPLES_CLEAN) $(NO_STD_ONLY_EXAMPLES_CLEAN) $(COMMON_EXAMPLES_CLEAN)
+
+$(STD_ONLY_EXAMPLES_CLEAN) $(NO_STD_ONLY_EXAMPLES_CLEAN) $(COMMON_EXAMPLES_CLEAN):
+	$(q)make -C $(@:-clean=) clean
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  std-examples         - Build std examples (std-only + common)"
+	@echo "  no-std-examples      - Build no-std examples (no-std-only + common)"
+	@echo "  std-only-examples    - Build std-only examples (requires STD=y)"
+	@echo "  no-std-only-examples - Build no-std-only examples (requires STD unset)"
+	@echo "  common-examples      - Build examples that work in both modes"
+	@echo "  clean                - Clean all examples"
+
+.PHONY: std-examples no-std-examples std-only-examples no-std-only-examples common-examples \
+	$(STD_ONLY_EXAMPLES) $(NO_STD_ONLY_EXAMPLES) $(COMMON_EXAMPLES) \
+	$(STD_ONLY_EXAMPLES_CLEAN) $(NO_STD_ONLY_EXAMPLES_CLEAN) $(COMMON_EXAMPLES_CLEAN) clean help

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,8 +37,11 @@ COMMON_EXAMPLES = \
 	big_int-rs \
 	diffie_hellman-rs \
 	digest-rs \
+	error_handling-rs \
 	hello_world-rs \
 	hotp-rs \
+	inter_ta-rs \
+	property-rs \
 	random-rs \
 	secure_storage-rs \
 	supp_plugin-rs \

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/build_with_optee_utee_sys-rs/ta/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/ta/Makefile
@@ -27,12 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
 all: ta strip sign
-else
-all:
-	@echo "Please \`unset STD\` then rerun \`source environment\` to build the No-STD version"
-endif
 
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)

--- a/examples/client_pool-rs/ta/Makefile
+++ b/examples/client_pool-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/error_handling-rs/ta/Makefile
+++ b/examples/error_handling-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/inter_ta-rs/ta/Makefile
+++ b/examples/inter_ta-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/message_passing_interface-rs/host/Makefile
+++ b/examples/message_passing_interface-rs/host/Makefile
@@ -24,12 +24,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/message_passing_interface-rs/ta/Makefile
+++ b/examples/message_passing_interface-rs/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/mnist-rs/ta/inference/Makefile
+++ b/examples/mnist-rs/ta/inference/Makefile
@@ -30,12 +30,7 @@ SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
 
 
-ifeq ($(STD),)
 all: ta strip sign
-else
-all:
-	@echo "Please \`unset STD\` then rerun \`source environment\` to build the No-STD version"
-endif
 
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)

--- a/examples/mnist-rs/ta/train/Makefile
+++ b/examples/mnist-rs/ta/train/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
 
-ifeq ($(STD),)
 all: ta strip sign
-else
-all:
-	@echo "Please \`unset STD\` then rerun \`source environment\` to build the No-STD version"
-endif
 
 ta:
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)

--- a/examples/property-rs/ta/Makefile
+++ b/examples/property-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/secure_db_abstraction-rs/host/Makefile
+++ b/examples/secure_db_abstraction-rs/host/Makefile
@@ -26,12 +26,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/secure_db_abstraction-rs/ta/Makefile
+++ b/examples/secure_db_abstraction-rs/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/serde-rs/host/Makefile
+++ b/examples/serde-rs/host/Makefile
@@ -24,12 +24,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/serde-rs/ta/Makefile
+++ b/examples/serde-rs/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/tcp_client-rs/ta/Makefile
+++ b/examples/tcp_client-rs/ta/Makefile
@@ -29,7 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -27,7 +27,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/examples/tls_client-rs/host/Makefile
+++ b/examples/tls_client-rs/host/Makefile
@@ -24,12 +24,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/tls_client-rs/ta/Makefile
+++ b/examples/tls_client-rs/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/tls_server-rs/host/Makefile
+++ b/examples/tls_server-rs/host/Makefile
@@ -24,12 +24,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/tls_server-rs/ta/Makefile
+++ b/examples/tls_server-rs/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/udp_socket-rs/ta/Makefile
+++ b/examples/udp_socket-rs/ta/Makefile
@@ -29,7 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-BUILDER = $(if $(STD),xargo,cargo)
+BUILDER ?= $(if $(STD),xargo,cargo)
 
 all: ta strip sign
 

--- a/projects/web3/eth_wallet/host/Makefile
+++ b/projects/web3/eth_wallet/host/Makefile
@@ -24,12 +24,7 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: host strip
-endif
 
 host:
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/projects/web3/eth_wallet/ta/Makefile
+++ b/projects/web3/eth_wallet/ta/Makefile
@@ -29,12 +29,7 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET_TA)/release
 
-ifeq ($(STD),)
-all:
-	@echo "Please \`export STD=y\` then rerun \`source environment\` to build the STD version"
-else
 all: ta strip sign
-endif
 
 ta:
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/scripts/setup-std/setup_rust_std.sh
+++ b/scripts/setup-std/setup_rust_std.sh
@@ -32,7 +32,7 @@ mkdir -p $RUST_STD_DIR
 cd $RUST_STD_DIR
 
 # install Xargo if not exist
-which xargo || cargo +stable install xargo
+which xargo || cargo install xargo
 
 # initialize submodules: rust / libc with pinned versions for reproducible builds
 RUST_BRANCH=optee-xargo

--- a/setup_std_dependencies.sh
+++ b/setup_std_dependencies.sh
@@ -25,7 +25,7 @@ cd "$(dirname "$0")"
 
 ##########################################
 # install Xargo if not exist
-which xargo || cargo +stable install xargo
+which xargo || cargo install xargo
 
 ##########################################
 # initialize submodules: rust / libc


### PR DESCRIPTION
The original `Makefile` used `$(wildcard examples/*)` to build all examples, but this caused several problems:
- **Mixed `std` and `no-std` examples** without clear separation, leading to confusion when running `make` on all examples.  
- **Unclear environment variable handling** – `STD` was checked in the Makefile logic without error reporting, forcing builds to follow the `STD` environment convention but giving no feedback to CI when mismatches occurred.  
- **No explicit build targets** for different modes, causing CI to attempt building all examples in a `no-std` environment.  
- **Poor discoverability** – it was hard to tell which examples supported which build modes.  

### Solution
- **Split examples into logical categories**: `std-only`, `no-std-only`, and `common` examples
- **Created explicit targets**: `std-examples`, `no-std-examples`, `std-only-examples`, `no-std-only-examples`, `common-examples`
- **Moved build logic to `examples/Makefile`**: Better modularity and separation of concerns
- **Removed environment variable checks**: Makefile no longer decides build mode, caller chooses explicitly
- **Maintained backward compatibility**: `make examples` defaults to no-std examples

### Changes
- **Top-level `Makefile`**: Now delegates to `examples/Makefile` and provides clean user interface
- **New `examples/Makefile`**: Contains all example-specific build logic and categorization
- **Updated documentation**: Added std/no-std support column to examples overview
- **Updated CI**: Changed from `make -j` to explicit `make examples` and `make std-examples` targets

### Bug Fixes
- **Fixed xargo installation**: Changed `cargo +stable install xargo` to `cargo install xargo` to use project's Rust toolchain

### CI Impact
- **No-std jobs**: Continue working unchanged (`make examples` builds no-std examples)
- **Std jobs**: Now use `make std-examples` instead of `STD=y && make`

This refactoring makes the build system more explicit, maintainable, and easier to understand while preserving all existing functionality.