### PR TITLE
lint: clippy enforcement and fix for all examples

### DIFF
--- a/examples/acipher-rs/host/Makefile
+++ b/examples/acipher-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/acipher-rs/ta/build.rs
+++ b/examples/acipher-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/acipher-rs/ta/src/main.rs
+++ b/examples/acipher-rs/ta/src/main.rs
@@ -96,9 +96,12 @@ fn encrypt(rsa: &mut RsaCipher, params: &mut Parameters) -> Result<()> {
         Err(e) => Err(e),
         Ok(cipher) => {
             cipher.set_key(&rsa.key)?;
-            match cipher.encrypt(&[], &plain_text) {
+            match cipher.encrypt(&[], plain_text) {
                 Err(e) => Err(e),
-                Ok(cipher_text) => Ok(p1.buffer().clone_from_slice(&cipher_text)),
+                Ok(cipher_text) => {
+                    p1.buffer().clone_from_slice(&cipher_text);
+                    Ok(())
+                }
             }
         }
     }
@@ -107,7 +110,7 @@ fn encrypt(rsa: &mut RsaCipher, params: &mut Parameters) -> Result<()> {
 fn decrypt(rsa: &mut RsaCipher, params: &mut Parameters) -> Result<()> {
     let key_info = rsa.key.info().unwrap();
     let mut p0 = unsafe { params.0.as_memref().unwrap() };
-    let mut cipher_text = p0.buffer();
+    let cipher_text = p0.buffer();
     let mut p1 = unsafe { params.1.as_memref().unwrap() };
     match Asymmetric::allocate(
         AlgorithmId::RsaesPkcs1V15,
@@ -117,9 +120,12 @@ fn decrypt(rsa: &mut RsaCipher, params: &mut Parameters) -> Result<()> {
         Err(e) => Err(e),
         Ok(cipher) => {
             cipher.set_key(&rsa.key)?;
-            match cipher.decrypt(&mut [], &mut cipher_text) {
+            match cipher.decrypt(&[], cipher_text) {
                 Err(e) => Err(e),
-                Ok(plain_text) => Ok(p1.buffer().clone_from_slice(&plain_text)),
+                Ok(plain_text) => {
+                    p1.buffer().clone_from_slice(&plain_text);
+                    Ok(())
+                }
             }
         }
     }

--- a/examples/aes-rs/host/Makefile
+++ b/examples/aes-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/aes-rs/ta/build.rs
+++ b/examples/aes-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/authentication-rs/host/Makefile
+++ b/examples/authentication-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/authentication-rs/ta/build.rs
+++ b/examples/authentication-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/big_int-rs/host/Makefile
+++ b/examples/big_int-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/big_int-rs/ta/build.rs
+++ b/examples/big_int-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/build_with_optee_utee_sys-rs/host/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG) -vv
 
 strip: host

--- a/examples/build_with_optee_utee_sys-rs/host/src/main.rs
+++ b/examples/build_with_optee_utee_sys-rs/host/src/main.rs
@@ -28,10 +28,10 @@ fn inc_value(session: &mut Session) -> optee_teec::Result<u32> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).map_err(|_|ErrorKind::BadParameters)?;
+    let uuid = Uuid::parse_str(UUID).map_err(|_| ErrorKind::BadParameters)?;
     // Ensure that multiple sessions can be opened concurrently.
-    let mut session1= ctx.open_session(uuid.clone())?;
-    let mut session2= ctx.open_session(uuid)?;
+    let mut session1 = ctx.open_session(uuid.clone())?;
+    let mut session2 = ctx.open_session(uuid)?;
     // Ensure that each session can successfully perform a call.
     println!("result is: {}", inc_value(&mut session1)?);
     println!("result is: {}", inc_value(&mut session2)?);

--- a/examples/build_with_optee_utee_sys-rs/ta/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/ta/Makefile
@@ -22,15 +22,21 @@ CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+RUSTFLAGS := -C panic=abort
 
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/build_with_optee_utee_sys-rs/ta/build.rs
+++ b/examples/build_with_optee_utee_sys-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     // For Rust editions 2018 and earlier, You must set workspace.resolver = "2"
@@ -29,12 +28,10 @@ fn main() -> Result<(), Error> {
     // For reference:
     // 1. resolver version 2: https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
     // 2. resolver versions: https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
-    let flags: u32 = optee_utee_sys::TA_FLAG_SINGLE_INSTANCE |
-        optee_utee_sys::TA_FLAG_MULTI_SESSION |
-        optee_utee_sys::TA_FLAG_INSTANCE_KEEP_ALIVE;
+    let flags: u32 = optee_utee_sys::TA_FLAG_SINGLE_INSTANCE
+        | optee_utee_sys::TA_FLAG_MULTI_SESSION
+        | optee_utee_sys::TA_FLAG_INSTANCE_KEEP_ALIVE;
 
-    let config = TaConfig::new_default_with_cargo_env(proto::UUID)?.
-        ta_flags(flags);
+    let config = TaConfig::new_default_with_cargo_env(proto::UUID)?.ta_flags(flags);
     optee_utee_build::build(RustEdition::Before2024, config)
-
 }

--- a/examples/build_with_optee_utee_sys-rs/ta/src/main.rs
+++ b/examples/build_with_optee_utee_sys-rs/ta/src/main.rs
@@ -18,12 +18,12 @@
 #![no_std]
 #![no_main]
 
+use core::sync::atomic::{AtomicU32, Ordering};
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
 use optee_utee::{Error, ErrorKind, Parameters, Result};
 use proto::Command;
-use core::sync::atomic::{AtomicU32, Ordering};
 
 static GLOBAL_VALUE: AtomicU32 = AtomicU32::new(0);
 

--- a/examples/client_pool-rs/host/Makefile
+++ b/examples/client_pool-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/client_pool-rs/ta/Makefile
+++ b/examples/client_pool-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/diffie_hellman-rs/host/Makefile
+++ b/examples/diffie_hellman-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/diffie_hellman-rs/host/src/main.rs
+++ b/examples/diffie_hellman-rs/host/src/main.rs
@@ -21,11 +21,11 @@ use proto::{Command, KEY_SIZE, UUID};
 
 fn generate_key(session: &mut Session) -> Result<(Vec<u8>, Vec<u8>)> {
     // Pass in the prime and base
-    let prime_base_vec = [0xB6, 0x73, 0x91, 0xB5, 0xD6, 0xBC, 0x95, 0x73, 
-                          0x0D, 0x53, 0x64, 0x13, 0xB0, 0x51, 0xC6, 0xB4, 
-                          0xEB, 0x9D, 0x74, 0x57, 0x8D, 0x65, 0x3A, 0x4B, 
-                          0x7A, 0xB2, 0x93, 0x27, 0xA6, 0xC1, 0xBC, 0xAB, 
-                          5];
+    let prime_base_vec = [
+        0xB6, 0x73, 0x91, 0xB5, 0xD6, 0xBC, 0x95, 0x73, 0x0D, 0x53, 0x64, 0x13, 0xB0, 0x51, 0xC6,
+        0xB4, 0xEB, 0x9D, 0x74, 0x57, 0x8D, 0x65, 0x3A, 0x4B, 0x7A, 0xB2, 0x93, 0x27, 0xA6, 0xC1,
+        0xBC, 0xAB, 5,
+    ];
     let p0 = ParamTmpRef::new_input(&prime_base_vec);
     // Save public and private key size
     let p1 = ParamValue::new(0, 0, ParamType::ValueOutput);
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
     let uuid = Uuid::parse_str(UUID).unwrap();
     let mut session = ctx.open_session(uuid)?;
 
-    let (mut key0_public, key0_private) = generate_key(&mut session).unwrap();
+    let (key0_public, key0_private) = generate_key(&mut session).unwrap();
     let (key1_public, key1_private) = generate_key(&mut session).unwrap();
     println!(
         "get key 0 pair as public: {:?}, private: {:?}",
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
         "get key 1 pair as public: {:?}, private: {:?}",
         key1_public, key1_private
     );
-    derive_key(&mut key0_public, &mut session)?;
+    derive_key(&key0_public, &mut session)?;
 
     println!("Success");
     Ok(())

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/diffie_hellman-rs/ta/build.rs
+++ b/examples/diffie_hellman-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/diffie_hellman-rs/ta/src/main.rs
+++ b/examples/diffie_hellman-rs/ta/src/main.rs
@@ -25,7 +25,9 @@ use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
 use optee_utee::{AlgorithmId, DeriveKey};
-use optee_utee::{AttributeId, AttributeMemref, GenericObject, TransientObject, TransientObjectType};
+use optee_utee::{
+    AttributeId, AttributeMemref, GenericObject, TransientObject, TransientObjectType,
+};
 use optee_utee::{Error, ErrorKind, Parameters, Result};
 use proto::{Command, KEY_SIZE};
 
@@ -71,27 +73,27 @@ fn generate_key(dh: &mut DiffieHellman, params: &mut Parameters) -> Result<()> {
 
     // Extract prime and base from parameters
     let prime_base_vec = p0.buffer();
-    let prime_slice = &prime_base_vec[..KEY_SIZE/8];
-    let base_slice = &prime_base_vec[KEY_SIZE/8..];
+    let prime_slice = &prime_base_vec[..KEY_SIZE / 8];
+    let base_slice = &prime_base_vec[KEY_SIZE / 8..];
 
     let attr_prime = AttributeMemref::from_ref(AttributeId::DhPrime, prime_slice);
     let attr_base = AttributeMemref::from_ref(AttributeId::DhBase, base_slice);
 
     // Generate key pair
     dh.key = TransientObject::allocate(TransientObjectType::DhKeypair, KEY_SIZE).unwrap();
-    let mut public_buffer = p2.buffer();
-    let mut private_buffer = p3.buffer();
+    let public_buffer = p2.buffer();
+    let private_buffer = p3.buffer();
 
     dh.key
         .generate_key(KEY_SIZE, &[attr_prime.into(), attr_base.into()])?;
     let mut key_size = dh
         .key
-        .ref_attribute(AttributeId::DhPublicValue, &mut public_buffer)
+        .ref_attribute(AttributeId::DhPublicValue, public_buffer)
         .unwrap();
     p1.set_a(key_size as u32);
     key_size = dh
         .key
-        .ref_attribute(AttributeId::DhPrivateValue, &mut private_buffer)
+        .ref_attribute(AttributeId::DhPrivateValue, private_buffer)
         .unwrap();
     p1.set_b(key_size as u32);
     Ok(())
@@ -128,12 +130,8 @@ fn invoke_command(
 ) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
-        Command::GenerateKey => {
-            return generate_key(sess_ctx, params);
-        }
-        Command::DeriveKey => {
-            return derive_key(sess_ctx, params);
-        }
+        Command::GenerateKey => generate_key(sess_ctx, params),
+        Command::DeriveKey => derive_key(sess_ctx, params),
         _ => Err(Error::new(ErrorKind::BadParameters)),
     }
 }

--- a/examples/digest-rs/host/Makefile
+++ b/examples/digest-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/digest-rs/host/src/main.rs
+++ b/examples/digest-rs/host/src/main.rs
@@ -56,8 +56,8 @@ fn main() -> optee_teec::Result<()> {
     let mut hash: [u8; 32] = [0u8; 32];
     let mut session = ctx.open_session(uuid)?;
 
-    for i in 1..args_len - 1 {
-        update(&mut session, args[i].as_bytes())?;
+    for arg in &args[1..args_len - 1] {
+        update(&mut session, arg.as_bytes())?;
     }
 
     let hash_length = do_final(&mut session, args[args_len - 1].as_bytes(), &mut hash).unwrap();

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/digest-rs/ta/build.rs
+++ b/examples/digest-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/digest-rs/ta/src/main.rs
+++ b/examples/digest-rs/ta/src/main.rs
@@ -66,15 +66,9 @@ fn destroy() {
 fn invoke_command(sess_ctx: &mut DigestOp, cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
-        Command::Update => {
-            return update(sess_ctx, params);
-        }
-        Command::DoFinal => {
-            return do_final(sess_ctx, params);
-        }
-        _ => {
-            return Err(Error::new(ErrorKind::BadParameters));
-        }
+        Command::Update => update(sess_ctx, params),
+        Command::DoFinal => do_final(sess_ctx, params),
+        _ => Err(Error::new(ErrorKind::BadParameters)),
     }
 }
 

--- a/examples/error_handling-rs/host/Makefile
+++ b/examples/error_handling-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/error_handling-rs/host/src/main.rs
+++ b/examples/error_handling-rs/host/src/main.rs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use optee_teec::{Context, ErrorKind, Operation, ParamType, Session, Uuid};
 use optee_teec::ParamNone;
-use proto::{UUID, Command};
+use optee_teec::{Context, ErrorKind, Operation, Uuid};
+use proto::{Command, UUID};
 
 fn main() -> optee_teec::Result<()> {
     test_error_handling();
@@ -31,14 +31,20 @@ fn test_error_handling() {
     let mut operation = Operation::new(0, ParamNone, ParamNone, ParamNone, ParamNone);
 
     // Test successful invocation return Ok().
-    session.invoke_command(Command::ReturnSuccess as u32, &mut operation).expect("success");
+    session
+        .invoke_command(Command::ReturnSuccess as u32, &mut operation)
+        .expect("success");
 
     // Test error invocation returns the requested error.
-    let e = session.invoke_command(Command::ReturnGenericError as u32, &mut operation).expect_err("generic error");
+    let e = session
+        .invoke_command(Command::ReturnGenericError as u32, &mut operation)
+        .expect_err("generic error");
     assert_eq!(e.kind(), ErrorKind::Generic);
 
     // Test repeated error invocation also returns the requested error.
-    let e = session.invoke_command(Command::ReturnGenericError as u32, &mut operation).expect_err("generic error");
+    let e = session
+        .invoke_command(Command::ReturnGenericError as u32, &mut operation)
+        .expect_err("generic error");
     assert_eq!(e.kind(), ErrorKind::Generic);
 
     println!("Test passed");

--- a/examples/error_handling-rs/ta/Makefile
+++ b/examples/error_handling-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/error_handling-rs/ta/build.rs
+++ b/examples/error_handling-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/error_handling-rs/ta/src/main.rs
+++ b/examples/error_handling-rs/ta/src/main.rs
@@ -31,13 +31,13 @@ use optee_utee::{Error, ErrorKind, Parameters, Result};
 use proto::Command;
 
 pub struct SessionContext {
-    stuff_on_heap: Vec<u8>,
+    _stuff_on_heap: Vec<u8>,
 }
 
 impl Default for SessionContext {
     fn default() -> Self {
         Self {
-            stuff_on_heap: vec![1, 2, 3, 4],
+            _stuff_on_heap: vec![1, 2, 3, 4],
         }
     }
 }
@@ -68,7 +68,7 @@ fn destroy() {
 fn invoke_command(
     _sess_ctx: &mut SessionContext,
     cmd_id: u32,
-    params: &mut Parameters,
+    _params: &mut Parameters,
 ) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {

--- a/examples/hello_world-rs/host/Makefile
+++ b/examples/hello_world-rs/host/Makefile
@@ -23,12 +23,15 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
 .PHONY: all host strip clean emulate
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/hello_world-rs/host/src/main.rs
+++ b/examples/hello_world-rs/host/src/main.rs
@@ -17,7 +17,7 @@
 
 use optee_teec::{Context, Operation, ParamType, Session, Uuid};
 use optee_teec::{ParamNone, ParamValue};
-use proto::{UUID, Command};
+use proto::{Command, UUID};
 
 fn hello_world(session: &mut Session) -> optee_teec::Result<()> {
     let p0 = ParamValue::new(29, 0, ParamType::ValueInout);

--- a/examples/hello_world-rs/ta/Makefile
+++ b/examples/hello_world-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/hello_world-rs/ta/build.rs
+++ b/examples/hello_world-rs/ta/build.rs
@@ -15,11 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;
     optee_utee_build::build(RustEdition::Before2024, config)
-
 }

--- a/examples/hotp-rs/host/Makefile
+++ b/examples/hotp-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/hotp-rs/host/src/main.rs
+++ b/examples/hotp-rs/host/src/main.rs
@@ -44,18 +44,15 @@ fn get_hotp(session: &mut Session) -> optee_teec::Result<()> {
     let p0 = ParamValue::new(0, 0, ParamType::ValueOutput);
     let mut operation = Operation::new(0, p0, ParamNone, ParamNone, ParamNone);
 
-    for i in 0..TEST_SIZE {
+    for &expected_value in &RFC4226_TEST_VALUES {
         session.invoke_command(Command::GetHOTP as u32, &mut operation)?;
         let (p0, _, _, _) = operation.parameters();
         let hotp_value = p0.a();
 
         println!("Get HOTP: {}", hotp_value);
 
-        if hotp_value != RFC4226_TEST_VALUES[i] {
-            println!(
-                "Wrong value get! Expected value: {}",
-                RFC4226_TEST_VALUES[i]
-            );
+        if hotp_value != expected_value {
+            println!("Wrong value get! Expected value: {}", expected_value);
             return Err(Error::new(ErrorKind::Generic));
         }
     }

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/hotp-rs/ta/build.rs
+++ b/examples/hotp-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/inter_ta-rs/host/Makefile
+++ b/examples/inter_ta-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/inter_ta-rs/ta/Makefile
+++ b/examples/inter_ta-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/inter_ta-rs/ta/build.rs
+++ b/examples/inter_ta-rs/ta/build.rs
@@ -16,11 +16,10 @@
 // under the License.
 
 use optee_utee_build::{Error, RustEdition, TaConfig};
-use proto;
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?
-        .ta_data_size(1 * 1024 * 1024)
-        .ta_stack_size(1 * 1024 * 1024);
+        .ta_data_size(1024 * 1024)
+        .ta_stack_size(1024 * 1024);
     optee_utee_build::build(RustEdition::Before2024, config)
 }

--- a/examples/inter_ta-rs/ta/src/main.rs
+++ b/examples/inter_ta-rs/ta/src/main.rs
@@ -143,9 +143,7 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             trace_println!("[+] Test passed");
             Ok(())
         }
-        _ => {
-            return Err(Error::new(ErrorKind::NotSupported));
-        }
+        _ => Err(Error::new(ErrorKind::NotSupported)),
     }
 }
 

--- a/examples/message_passing_interface-rs/host/Makefile
+++ b/examples/message_passing_interface-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/message_passing_interface-rs/host/src/main.rs
+++ b/examples/message_passing_interface-rs/host/src/main.rs
@@ -16,8 +16,6 @@
 // under the License.
 
 use optee_teec::{Context, Operation, ParamNone, ParamTmpRef, ParamType, ParamValue, Uuid};
-use proto;
-use url;
 
 type Result<T> = optee_teec::Result<T>;
 
@@ -40,7 +38,7 @@ impl EnclaveClient {
         let context = Context::new()?;
         Ok(Self {
             uuid: uuid.to_string(),
-            context: context,
+            context,
             buffer: vec![0; 128],
         })
     }

--- a/examples/message_passing_interface-rs/ta/Cargo.lock
+++ b/examples/message_passing_interface-rs/ta/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "optee-utee"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "prettyplease",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "quote 0.6.13",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
 ]

--- a/examples/message_passing_interface-rs/ta/Makefile
+++ b/examples/message_passing_interface-rs/ta/Makefile
@@ -19,7 +19,7 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
+TARGET ?= aarch64-unknown-optee
 CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/examples/message_passing_interface-rs/ta/build.rs
+++ b/examples/message_passing_interface-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?

--- a/examples/message_passing_interface-rs/ta/src/main.rs
+++ b/examples/message_passing_interface-rs/ta/src/main.rs
@@ -75,7 +75,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     let output = handle_invoke(Command::from(cmd_id), input).unwrap();
 
     let output_vec = proto::serde_json::to_vec(&output).unwrap();
-    p1.buffer().write(&output_vec).unwrap();
+    p1.buffer().write_all(&output_vec).unwrap();
     p2.set_a(output_vec.len() as u32);
 
     Ok(())

--- a/examples/mnist-rs/host/Makefile
+++ b/examples/mnist-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/mnist-rs/host/src/commands/infer.rs
+++ b/examples/mnist-rs/host/src/commands/infer.rs
@@ -48,7 +48,7 @@ pub fn execute(args: &Args) -> anyhow::Result<()> {
             anyhow::ensure!(data.len() == IMAGE_SIZE);
 
             TryInto::<Image>::try_into(data)
-                .map_err(|err| anyhow::Error::msg(format!("cannot convert {:?} into Image", err)))
+                .map_err(|err| anyhow::Error::msg(format!("cannot convert {err:?} into Image")))
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
     let images: Vec<Image> = args
@@ -59,7 +59,7 @@ pub fn execute(args: &Args) -> anyhow::Result<()> {
             let bytes = img.as_bytes();
             anyhow::ensure!(bytes.len() == IMAGE_SIZE);
             TryInto::<Image>::try_into(bytes)
-                .map_err(|err| anyhow::Error::msg(format!("cannot convert {:?} into Image", err)))
+                .map_err(|err| anyhow::Error::msg(format!("cannot convert {err:?} into Image")))
         })
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
     binaries.extend(images);

--- a/examples/mnist-rs/host/src/commands/serve.rs
+++ b/examples/mnist-rs/host/src/commands/serve.rs
@@ -40,17 +40,17 @@ pub fn execute(args: &Args) -> anyhow::Result<()> {
     let mut caller = crate::tee::InferenceTaConnector::new(&mut ctx, &record)?;
 
     let addr = format!("0.0.0.0:{}", args.port);
-    println!("Server runs on: {}", addr);
+    println!("Server runs on: {addr}");
 
     let server = Server::http(&addr)
-        .map_err(|err| anyhow::Error::msg(format!("cannot start server: {:?}", err)))?;
+        .map_err(|err| anyhow::Error::msg(format!("cannot start server: {err:?}")))?;
 
     loop {
         let mut request = server.recv()?;
         let response = match handle(&mut caller, &mut request) {
             Ok(v) => v,
             Err(err) => {
-                eprintln!("unexpected error: {:#?}", err);
+                eprintln!("unexpected error: {err:#?}");
                 Response::from_string("Internal Error").with_status_code(500)
             }
         };
@@ -88,7 +88,7 @@ fn handle_image(
     }
     let result = handle_infer(caller, img.as_bytes())?;
 
-    println!("Performing Inference with Image, Result is {}", result);
+    println!("Performing Inference with Image, Result is {result}");
     Ok(Response::from_data(result.to_string()))
 }
 
@@ -103,14 +103,11 @@ fn handle_binary(
     }
 
     let result = handle_infer(caller, &data)?;
-    println!("Performing Inference with Binary, Result is {}", result);
+    println!("Performing Inference with Binary, Result is {result}");
     Ok(Response::from_data(result.to_string()))
 }
 
-fn handle_infer(
-    caller: &mut crate::tee::InferenceTaConnector,
-    image: &[u8],
-) -> anyhow::Result<u8> {
+fn handle_infer(caller: &mut crate::tee::InferenceTaConnector, image: &[u8]) -> anyhow::Result<u8> {
     let result = caller.infer_batch(bytemuck::cast_slice(image))?;
     Ok(result[0])
 }

--- a/examples/mnist-rs/host/src/commands/train.rs
+++ b/examples/mnist-rs/host/src/commands/train.rs
@@ -79,7 +79,7 @@ pub fn execute(args: &Args) -> anyhow::Result<()> {
     // Export the model to the given path
     if let Some(output_path) = args.output.as_ref() {
         let record = trainer.export()?;
-        println!("Export record to \"{}\"", output_path);
+        println!("Export record to \"{output_path}\"");
         std::fs::write(output_path, &record)?;
     }
     println!("Train Success");
@@ -111,11 +111,8 @@ fn check_download_mnist_data() -> anyhow::Result<rust_mnist::Mnist> {
             continue;
         }
 
-        let url = format!(
-            "https://storage.googleapis.com/cvdf-datasets/mnist/{}.gz",
-            filename
-        );
-        println!("Download {} from {}", filename, url);
+        let url = format!("https://storage.googleapis.com/cvdf-datasets/mnist/{filename}.gz");
+        println!("Download {filename} from {url}");
         let body = ureq::get(&url).call()?.body_mut().read_to_vec()?;
 
         anyhow::ensure!(body.len() == *compressed_size as usize);

--- a/examples/mnist-rs/host/src/tee.rs
+++ b/examples/mnist-rs/host/src/tee.rs
@@ -18,7 +18,7 @@
 use optee_teec::{Context, ErrorKind, Operation, ParamNone, ParamTmpRef, Session, Uuid};
 use proto::{inference, train, Image};
 
-const MAX_OUTPUT_SERIALIZE_SIZE: usize = 1 * 1024;
+const MAX_OUTPUT_SERIALIZE_SIZE: usize = 1024;
 const MAX_MODEL_RECORD_SIZE: usize = 10 * 1024 * 1024;
 
 pub struct TrainerTaConnector {
@@ -60,7 +60,7 @@ impl TrainerTaConnector {
             op.parameters().2.updated_size()
         };
         let result = serde_json::from_slice(&buffer[0..size]).map_err(|err| {
-            println!("proto error: {:?}", err);
+            println!("proto error: {err:?}");
             ErrorKind::BadFormat
         })?;
         Ok(result)
@@ -81,7 +81,7 @@ impl TrainerTaConnector {
             op.parameters().2.updated_size()
         };
         let result = serde_json::from_slice(&buffer[0..size]).map_err(|err| {
-            println!("proto error: {:?}", err);
+            println!("proto error: {err:?}");
             ErrorKind::BadFormat
         })?;
         Ok(result)

--- a/examples/mnist-rs/rust-toolchain.toml
+++ b/examples/mnist-rs/rust-toolchain.toml
@@ -19,7 +19,7 @@
 
 [toolchain]
 channel = "nightly-2025-05-16"
-components = [ "rust-src" ]
+components = [ "rust-src", "rustfmt", "clippy" ]
 targets = ["aarch64-unknown-linux-gnu", "arm-unknown-linux-gnueabihf"]
 # minimal profile: install rustc, cargo, and rust-std
 profile = "minimal"

--- a/examples/mnist-rs/ta/inference/Makefile
+++ b/examples/mnist-rs/ta/inference/Makefile
@@ -23,17 +23,22 @@ CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-EXTRA_FLAGS = -Z build-std=core,alloc
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+RUSTFLAGS := -C panic=abort
+EXTRA_FLAGS = -Z build-std=core,alloc -Z build-std-features=panic_immediate_abort
 
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
 
+all: clippy ta strip sign
 
-all: ta strip sign
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings
 
-ta:
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/stripped_$(NAME)

--- a/examples/mnist-rs/ta/inference/build.rs
+++ b/examples/mnist-rs/ta/inference/build.rs
@@ -19,7 +19,7 @@ use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::train::UUID)?
-        .ta_data_size(1 * 1024 * 1024)
-        .ta_stack_size(1 * 1024 * 1024);
+        .ta_data_size(1024 * 1024)
+        .ta_stack_size(1024 * 1024);
     optee_utee_build::build(RustEdition::Before2024, config)
 }

--- a/examples/mnist-rs/ta/train/Makefile
+++ b/examples/mnist-rs/ta/train/Makefile
@@ -23,16 +23,22 @@ CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+RUSTFLAGS := -C panic=abort
 EXTRA_FLAGS = -Z build-std=core,alloc
 
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/stripped_$(NAME)

--- a/examples/mnist-rs/ta/train/build.rs
+++ b/examples/mnist-rs/ta/train/build.rs
@@ -20,6 +20,6 @@ use optee_utee_build::{Error, RustEdition, TaConfig};
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::train::UUID)?
         .ta_data_size(5 * 1024 * 1024)
-        .ta_stack_size(1 * 1024 * 1024);
+        .ta_stack_size(1024 * 1024);
     optee_utee_build::build(RustEdition::Before2024, config)
 }

--- a/examples/property-rs/host/Makefile
+++ b/examples/property-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/property-rs/ta/Makefile
+++ b/examples/property-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/property-rs/ta/build.rs
+++ b/examples/property-rs/ta/build.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use optee_utee_build::{Error, RustEdition, TaConfig};
-use proto;
 
 fn main() -> Result<(), Error> {
     let config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/property-rs/ta/src/main.rs
+++ b/examples/property-rs/ta/src/main.rs
@@ -105,9 +105,7 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             trace_println!("[+] Test passed");
             Ok(())
         }
-        _ => {
-            return Err(Error::new(ErrorKind::NotSupported));
-        }
+        _ => Err(Error::new(ErrorKind::NotSupported)),
     }
 }
 

--- a/examples/random-rs/host/Makefile
+++ b/examples/random-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/random-rs/ta/build.rs
+++ b/examples/random-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/random-rs/ta/src/main.rs
+++ b/examples/random-rs/ta/src/main.rs
@@ -21,11 +21,11 @@
 extern crate alloc;
 
 use alloc::vec;
+use optee_utee::Random;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
 use optee_utee::{Error, ErrorKind, Parameters, Result};
-use optee_utee::{Random};
 use proto::Command;
 
 #[ta_create]
@@ -51,8 +51,8 @@ fn destroy() {
 }
 
 pub fn random_number_generate(params: &mut Parameters) -> Result<()> {
-    let mut p = unsafe { params.0.as_memref().unwrap()};
-    let mut buf = vec![0; p.buffer().len() as usize];
+    let mut p = unsafe { params.0.as_memref().unwrap() };
+    let mut buf = vec![0; p.buffer().len()];
     buf.copy_from_slice(p.buffer());
 
     Random::generate(buf.as_mut() as _);
@@ -65,12 +65,8 @@ pub fn random_number_generate(params: &mut Parameters) -> Result<()> {
 fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
-        Command::RandomGenerator => {
-            return random_number_generate(params);
-        }
-        _ => {
-            return Err(Error::new(ErrorKind::BadParameters));
-        }
+        Command::RandomGenerator => random_number_generate(params),
+        _ => Err(Error::new(ErrorKind::BadParameters)),
     }
 }
 

--- a/examples/secure_db_abstraction-rs/host/Makefile
+++ b/examples/secure_db_abstraction-rs/host/Makefile
@@ -26,9 +26,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/secure_db_abstraction-rs/ta/Cargo.lock
+++ b/examples/secure_db_abstraction-rs/ta/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,30 @@ name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -75,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -88,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "prettyplease",
@@ -101,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "quote 0.6.13",
@@ -111,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
 ]
@@ -181,6 +211,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "hashbrown",
  "optee-utee",
  "optee-utee-sys",
  "serde",

--- a/examples/secure_db_abstraction-rs/ta/Makefile
+++ b/examples/secure_db_abstraction-rs/ta/Makefile
@@ -19,7 +19,7 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
+TARGET ?= aarch64-unknown-optee
 CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/examples/secure_db_abstraction-rs/ta/build.rs
+++ b/examples/secure_db_abstraction-rs/ta/build.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use optee_utee_build::{Error, RustEdition, TaConfig};
-use proto;
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/secure_db_abstraction-rs/ta/src/main.rs
+++ b/examples/secure_db_abstraction-rs/ta/src/main.rs
@@ -64,9 +64,7 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
                 Err(Error::new(ErrorKind::Generic))
             }
         },
-        _ => {
-            return Err(Error::new(ErrorKind::NotSupported));
-        }
+        _ => Err(Error::new(ErrorKind::NotSupported)),
     }
 }
 

--- a/examples/secure_storage-rs/host/Makefile
+++ b/examples/secure_storage-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/secure_storage-rs/ta/build.rs
+++ b/examples/secure_storage-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/serde-rs/host/Cargo.toml
+++ b/examples/serde-rs/host/Cargo.toml
@@ -25,7 +25,6 @@ description = "An example of Rust OP-TEE TrustZone SDK."
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 proto = { path = "../proto" }
 optee-teec = { path = "../../../optee-teec" }

--- a/examples/serde-rs/host/Makefile
+++ b/examples/serde-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/serde-rs/host/src/main.rs
+++ b/examples/serde-rs/host/src/main.rs
@@ -16,14 +16,7 @@
 // under the License.
 
 use optee_teec::{Context, Operation, ParamNone, ParamTmpRef, Session, Uuid};
-use proto::{Command, UUID};
-use serde::Deserialize;
-
-#[derive(Deserialize, Debug)]
-struct Point {
-    x: i32,
-    y: i32,
-}
+use proto::{Command, Point, UUID};
 
 fn serde(session: &mut Session) -> optee_teec::Result<()> {
     let mut buffer = [0u8; 128];

--- a/examples/serde-rs/proto/Cargo.toml
+++ b/examples/serde-rs/proto/Cargo.toml
@@ -26,3 +26,4 @@ edition = "2018"
 
 [dependencies]
 num_enum = { version = "0.7.3", default-features = false }
+serde = { version = "1.0", features = ["derive"] }

--- a/examples/serde-rs/proto/src/lib.rs
+++ b/examples/serde-rs/proto/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 use num_enum::{FromPrimitive, IntoPrimitive};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
 
 #[derive(FromPrimitive, IntoPrimitive)]
 #[repr(u32)]

--- a/examples/serde-rs/ta/Cargo.lock
+++ b/examples/serde-rs/ta/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "optee-utee"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "prettyplease",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "quote 0.6.13",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
 ]
@@ -180,6 +180,7 @@ name = "proto"
 version = "0.4.0"
 dependencies = [
  "num_enum",
+ "serde",
 ]
 
 [[package]]

--- a/examples/serde-rs/ta/Makefile
+++ b/examples/serde-rs/ta/Makefile
@@ -19,7 +19,7 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
+TARGET ?= aarch64-unknown-optee
 CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/examples/serde-rs/ta/build.rs
+++ b/examples/serde-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?

--- a/examples/serde-rs/ta/src/main.rs
+++ b/examples/serde-rs/ta/src/main.rs
@@ -21,8 +21,7 @@ use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
 use optee_utee::{Error, ErrorKind, Parameters, Result};
-use proto::Command;
-use serde::{Deserialize, Serialize};
+use proto::{Command, Point};
 use std::io::Write;
 
 #[ta_create]
@@ -45,12 +44,6 @@ fn close_session() {
 #[ta_destroy]
 fn destroy() {
     trace_println!("[+] TA destroy");
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct Point {
-    x: i32,
-    y: i32,
 }
 
 #[ta_invoke_command]

--- a/examples/signature_verification-rs/host/Makefile
+++ b/examples/signature_verification-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/signature_verification-rs/host/src/main.rs
+++ b/examples/signature_verification-rs/host/src/main.rs
@@ -65,11 +65,11 @@ fn main() -> optee_teec::Result<()> {
     let mut public_key = [0x00u8; PUBLIC_KEY_SIZE];
     let mut signature = [0x00u8; SIGNATURE_SIZE];
 
-    sign(&mut session, &message, &mut public_key, &mut signature)?;
+    sign(&mut session, message, &mut public_key, &mut signature)?;
     println!("CA: public key: {:?}", &public_key);
     println!("CA: signature: {:?}", &signature);
 
-    verify(&mut session, &message, &public_key, &signature)?;
+    verify(&mut session, message, &public_key, &signature)?;
     println!("Success");
 
     Ok(())

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/signature_verification-rs/ta/build.rs
+++ b/examples/signature_verification-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/signature_verification-rs/ta/src/main.rs
+++ b/examples/signature_verification-rs/ta/src/main.rs
@@ -24,7 +24,7 @@ use alloc::vec;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{AlgorithmId, AttributeId, AttributeMemref, Digest, Asymmetric, OperationMode};
+use optee_utee::{AlgorithmId, Asymmetric, AttributeId, AttributeMemref, Digest, OperationMode};
 use optee_utee::{Error, ErrorKind, Parameters, Result};
 use optee_utee::{GenericObject, TransientObject, TransientObjectType};
 use proto::Command;
@@ -71,18 +71,26 @@ fn sign(params: &mut Parameters) -> Result<()> {
     let mut pub_key_size: usize = 0;
     trace_println!("[+] message: {:?}", &message);
 
-    let rsa_key =
-        TransientObject::allocate(TransientObjectType::RsaKeypair, 2048 as usize).unwrap();
+    let rsa_key = TransientObject::allocate(TransientObjectType::RsaKeypair, 2048_usize).unwrap();
 
-    rsa_key.generate_key(2048 as usize, &[])?;
+    rsa_key.generate_key(2048_usize, &[])?;
 
-    match rsa_key.ref_attribute(AttributeId::RsaModulus, &mut p1.buffer()) {
-        Ok(len) => Ok(pub_key_size += len),
+    match rsa_key.ref_attribute(AttributeId::RsaModulus, p1.buffer()) {
+        Ok(len) => {
+            pub_key_size += len;
+            Ok(())
+        }
         Err(e) => Err(e),
     }?;
 
-    match rsa_key.ref_attribute(AttributeId::RsaPublicExponent, &mut p1.buffer()[pub_key_size..]) {
-        Ok(len) => Ok(pub_key_size += len),
+    match rsa_key.ref_attribute(
+        AttributeId::RsaPublicExponent,
+        &mut p1.buffer()[pub_key_size..],
+    ) {
+        Ok(len) => {
+            pub_key_size += len;
+            Ok(())
+        }
         Err(e) => Err(e),
     }?;
 
@@ -91,26 +99,30 @@ fn sign(params: &mut Parameters) -> Result<()> {
     let mut hash = [0u8; 32];
     let dig = Digest::allocate(AlgorithmId::Sha256).unwrap();
 
-    dig.do_final(&message, &mut hash)?;
+    dig.do_final(message, &mut hash)?;
 
     let key_info = rsa_key.info().unwrap();
-    let mut signature = p2.buffer();
+    let signature = p2.buffer();
 
-    let rsa = Asymmetric::allocate(AlgorithmId::RsassaPkcs1V15Sha256,
-                                   OperationMode::Sign,
-                                   key_info.object_size()).unwrap();
+    let rsa = Asymmetric::allocate(
+        AlgorithmId::RsassaPkcs1V15Sha256,
+        OperationMode::Sign,
+        key_info.object_size(),
+    )
+    .unwrap();
 
     rsa.set_key(&rsa_key)?;
-    match rsa.sign_digest(&[], &hash, &mut signature) {
+    match rsa.sign_digest(&[], &hash, signature) {
         Ok(len) => {
             trace_println!("[+] signature: {:?}", p2.buffer());
-            return Ok(p2.set_updated_size(len as usize));
+            p2.set_updated_size(len);
+            Ok(())
         }
         Err(e) => {
             trace_println!("[+] error: {:?}", e);
-            return Err(Error::new(ErrorKind::SignatureInvalid));
+            Err(Error::new(ErrorKind::SignatureInvalid))
         }
-    };
+    }
 }
 
 fn verify(params: &mut Parameters) -> Result<()> {
@@ -132,7 +144,7 @@ fn verify(params: &mut Parameters) -> Result<()> {
     trace_println!("[+] signature: {:?}", &signature);
 
     let mut rsa_pub_key =
-        TransientObject::allocate(TransientObjectType::RsaPublicKey, 2048 as usize).unwrap();
+        TransientObject::allocate(TransientObjectType::RsaPublicKey, 2048_usize).unwrap();
 
     let mod_attr = AttributeMemref::from_ref(AttributeId::RsaModulus, &pub_key_mod);
     let exp_attr = AttributeMemref::from_ref(AttributeId::RsaPublicExponent, &pub_key_exp);
@@ -142,37 +154,36 @@ fn verify(params: &mut Parameters) -> Result<()> {
     let mut hash = [0u8; 32];
     let dig = Digest::allocate(AlgorithmId::Sha256).unwrap();
 
-    dig.do_final(&message, &mut hash)?;
+    dig.do_final(message, &mut hash)?;
 
     let key_info = rsa_pub_key.info().unwrap();
 
-    let rsa = Asymmetric::allocate(AlgorithmId::RsassaPkcs1V15Sha256,
-                                   OperationMode::Verify,
-                                   key_info.object_size()).unwrap();
+    let rsa = Asymmetric::allocate(
+        AlgorithmId::RsassaPkcs1V15Sha256,
+        OperationMode::Verify,
+        key_info.object_size(),
+    )
+    .unwrap();
 
     rsa.set_key(&rsa_pub_key)?;
-    match rsa.verify_digest(&[], &hash, &signature) {
+    match rsa.verify_digest(&[], &hash, signature) {
         Ok(_) => {
             trace_println!("[+] verify ok");
-            return Ok(());
+            Ok(())
         }
         Err(e) => {
             trace_println!("[+] error: {:?}", e);
-            return Err(Error::new(ErrorKind::SignatureInvalid));
+            Err(Error::new(ErrorKind::SignatureInvalid))
         }
-    };
+    }
 }
 
 #[ta_invoke_command]
 fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
-        Command::Sign => {
-            return sign(params);
-        }
-        Command::Verify => {
-            return verify(params);
-        }
+        Command::Sign => sign(params),
+        Command::Verify => verify(params),
         _ => Err(Error::new(ErrorKind::BadParameters)),
     }
 }

--- a/examples/supp_plugin-rs/host/Makefile
+++ b/examples/supp_plugin-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/supp_plugin-rs/plugin/Makefile
+++ b/examples/supp_plugin-rs/plugin/Makefile
@@ -25,11 +25,15 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host
 
-all: host
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
 	cp $(CURDIR)/target/$(TARGET)/release/lib$(NAME).so $(CURDIR)/target/$(TARGET)/release/$(PLUGIN_UUID).plugin.so 
+
 clean:
 	@cargo clean

--- a/examples/supp_plugin-rs/plugin/build.rs
+++ b/examples/supp_plugin-rs/plugin/build.rs
@@ -29,7 +29,7 @@ fn main() -> std::io::Result<()> {
     let plugin_uuid = Uuid::parse_str(proto::PLUGIN_UUID).unwrap();
     let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = plugin_uuid.as_fields();
 
-    write!(buffer, "\n")?;
+    writeln!(buffer)?;
     write!(
         buffer,
         "const PLUGIN_UUID_STRUCT: optee_teec::raw::TEEC_UUID = optee_teec::raw::TEEC_UUID {{

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/tcp_client-rs/host/Makefile
+++ b/examples/tcp_client-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/tcp_client-rs/host/src/main.rs
+++ b/examples/tcp_client-rs/host/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> optee_teec::Result<()> {
     let port = listen_addr.port();
 
     let child = thread::spawn(move || {
-        for request in server.incoming_requests() {
+        if let Some(request) = server.incoming_requests().next() {
             println!(
                 "received request! method: {:?}, url: {:?}, headers: {:?}",
                 request.method(),
@@ -73,7 +73,6 @@ fn main() -> optee_teec::Result<()> {
 
             let response = tiny_http::Response::from_string("hello world");
             request.respond(response).unwrap();
-            break;
         }
     });
     // Use the IP address directly to ensure we're actually trying an IPv6

--- a/examples/tcp_client-rs/ta/Cargo.toml
+++ b/examples/tcp_client-rs/ta/Cargo.toml
@@ -30,6 +30,9 @@ optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
 optee-utee = { path = "../../../optee-utee" }
 cfg_block = "0.2.0"
 
+[features]
+std = []
+
 [build-dependencies]
 proto = { path = "../proto" }
 optee-utee-build = { path = "../../../optee-utee-build" }

--- a/examples/tcp_client-rs/ta/Makefile
+++ b/examples/tcp_client-rs/ta/Makefile
@@ -25,16 +25,27 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
+# Enable std feature when STD=y
+FEATURES := $(if $(STD),--features std,)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/tcp_client-rs/ta/build.rs
+++ b/examples/tcp_client-rs/ta/build.rs
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?
-        .ta_data_size(1 * 1024 * 1024)
+        .ta_data_size(1024 * 1024)
         .ta_stack_size(2 * 1024 * 1024);
     optee_utee_build::build(RustEdition::Before2024, ta_config)
 }

--- a/examples/tcp_client-rs/ta/src/main.rs
+++ b/examples/tcp_client-rs/ta/src/main.rs
@@ -15,13 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg_attr(not(target_os = "optee"), no_std)]
+// Use feature flag to detect STD environment
+// - Feature "std" means std is available
+// - No feature means no-std environment
+// Check `feature`, not `target_os`, to avoid:
+// error: unexpected `cfg` value: `optee` reported by clippy
+// This occurs because `optee` is not an upstream Rust target_os.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![no_main]
 
 cfg_block::cfg_block! {
-    // In Teaclave, if target_os = "optee", the codes is compiled with std.
+    // In Teaclave, if feature "std" is enabled, the codes is compiled with std.
     // Otherwise, no-std
-    if #[cfg(target_os = "optee")] {
+    if #[cfg(feature = "std")] {
         use std::io::{Read, Write};
     } else {
         extern crate alloc;

--- a/examples/time-rs/host/Makefile
+++ b/examples/time-rs/host/Makefile
@@ -24,10 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
+all: clippy host strip
 
-all: host strip
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
 
-host:
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -23,16 +23,24 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/time-rs/ta/build.rs
+++ b/examples/time-rs/ta/build.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?;

--- a/examples/time-rs/ta/src/main.rs
+++ b/examples/time-rs/ta/src/main.rs
@@ -67,11 +67,14 @@ fn time() -> Result<()> {
     Time::wait(1000)?;
     time.system_time();
     trace_println!("[+] Get system time {}.", time);
-    time.seconds = time.seconds + 5;
+    time.seconds += 5;
     time.set_ta_time()?;
     let mut time2 = Time::new();
     time2.ta_time()?;
-    trace_println!("[+] After set the TA time 5 seconds ahead of system time, new TA time {}.", time2);
+    trace_println!(
+        "[+] After set the TA time 5 seconds ahead of system time, new TA time {}.",
+        time2
+    );
     Ok(())
 }
 

--- a/examples/tls_client-rs/host/Makefile
+++ b/examples/tls_client-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/tls_client-rs/ta/Cargo.lock
+++ b/examples/tls_client-rs/ta/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "optee-utee"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "prettyplease",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "quote 0.6.13",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
 ]

--- a/examples/tls_client-rs/ta/Makefile
+++ b/examples/tls_client-rs/ta/Makefile
@@ -19,7 +19,7 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
+TARGET ?= aarch64-unknown-optee
 CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/examples/tls_server-rs/host/Makefile
+++ b/examples/tls_server-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/tls_server-rs/ta/Cargo.lock
+++ b/examples/tls_server-rs/ta/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "optee-utee"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-build"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "prettyplease",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "litemap",
  "quote 0.6.13",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "optee-utee-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
 ]

--- a/examples/tls_server-rs/ta/Makefile
+++ b/examples/tls_server-rs/ta/Makefile
@@ -19,7 +19,7 @@
 
 UUID ?= $(shell cat "../uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
+TARGET ?= aarch64-unknown-optee
 CROSS_COMPILE ?= aarch64-linux-gnu-
 OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/examples/udp_socket-rs/host/Makefile
+++ b/examples/udp_socket-rs/host/Makefile
@@ -24,9 +24,13 @@ LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
-all: host strip
+all: clippy host strip
 
-host:
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+
+host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
 
 strip: host

--- a/examples/udp_socket-rs/ta/Cargo.toml
+++ b/examples/udp_socket-rs/ta/Cargo.toml
@@ -30,6 +30,9 @@ optee-utee-sys = { path = "../../../optee-utee/optee-utee-sys" }
 optee-utee = { path = "../../../optee-utee" }
 cfg_block = "0.2.0"
 
+[features]
+std = []
+
 [build-dependencies]
 proto = { path = "../proto" }
 optee-utee-build = { path = "../../../optee-utee-build" }

--- a/examples/udp_socket-rs/ta/Makefile
+++ b/examples/udp_socket-rs/ta/Makefile
@@ -25,16 +25,27 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 # Configure the linker to use GCC, which works on both cross-compilation and ARM machines
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Only set panic=abort when STD is not enabled (no-std mode)
+RUSTFLAGS := $(if $(STD),,-C panic=abort)
+
+# Enable std feature when STD=y
+FEATURES := $(if $(STD),--features std,)
+
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
 
 BUILDER ?= $(if $(STD),xargo,cargo)
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
-	@$(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
 
 strip: ta
 	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta

--- a/examples/udp_socket-rs/ta/build.rs
+++ b/examples/udp_socket-rs/ta/build.rs
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use proto;
-use optee_utee_build::{TaConfig, RustEdition, Error};
+use optee_utee_build::{Error, RustEdition, TaConfig};
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?
-        .ta_data_size(1 * 1024 * 1024)
+        .ta_data_size(1024 * 1024)
         .ta_stack_size(2 * 1024 * 1024);
     optee_utee_build::build(RustEdition::Before2024, ta_config)
 }

--- a/examples/udp_socket-rs/ta/src/main.rs
+++ b/examples/udp_socket-rs/ta/src/main.rs
@@ -15,13 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![cfg_attr(not(target_os = "optee"), no_std)]
+// Use feature flag to detect STD environment
+// - Feature "std" means std is available
+// - No feature means no-std environment
+// Check `feature`, not `target_os`, to avoid:
+// error: unexpected `cfg` value: `optee` reported by clippy
+// This occurs because `optee` is not an upstream Rust target_os.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![no_main]
 
 cfg_block::cfg_block! {
-    // In Teaclave, if target_os = "optee", the codes is compiled with std.
+    // In Teaclave, if feature "std" is enabled, the codes is compiled with std.
     // Otherwise, no-std
-    if #[cfg(target_os = "optee")] {
+    if #[cfg(feature = "std")] {
         use std::io::{Read, Write};
     } else {
         extern crate alloc;

--- a/optee-teec/macros/src/lib.rs
+++ b/optee-teec/macros/src/lib.rs
@@ -129,6 +129,10 @@ pub fn plugin_invoke(_args: TokenStream, input: TokenStream) -> TokenStream {
         .into_token_stream();
 
     quote!(
+        // temporary workaround for this error:
+        // error: this public function might dereference a raw pointer but is not marked `unsafe`
+        // should remove this allow macro when fix clippy errors of optee-* crates
+        #[allow(clippy::not_unsafe_ptr_arg_deref)]
         pub fn _plugin_invoke(
             cmd: u32,
             sub_cmd: u32,

--- a/optee-utee-build/src/code_generator.rs
+++ b/optee-utee-build/src/code_generator.rs
@@ -93,9 +93,12 @@ impl HeaderFileGenerator {
         #no_mangle_attribute
         pub static trace_ext_prefix: &[u8] = #trace_ext;
 
+        /// # Safety
+        /// This function is called by the OP-TEE framework to get the trace level.
+        /// It's safe to call as it only reads a static variable.
         #no_mangle_attribute
         pub unsafe extern "C" fn tahead_get_trace_level() -> c_int {
-            unsafe { return trace_level; }
+            unsafe { trace_level }
         }
                 })
     }
@@ -342,7 +345,7 @@ mod tests {
         let uuid = "26509cec-4a2b-4935-87ab-762d89fbf0b0";
         let conf = TaConfig::new_default(uuid, "0.1.0", "test_before_2024")
             .unwrap()
-            .ta_data_size(1 * 1024 * 1024);
+            .ta_data_size(1024 * 1024);
         let generator = HeaderFileGenerator::new(RustEdition::Before2024);
         let codes = generator.generate(&conf).unwrap();
         let exp_result = include_str!("../test_files/test_edition_before_2024_result.rs");

--- a/optee-utee-build/test_files/test_edition_2024_result.rs
+++ b/optee-utee-build/test_files/test_edition_2024_result.rs
@@ -27,11 +27,12 @@ const TA_DESCRIPTION: &[u8] = b"test_edition_2024\0";
 pub static mut trace_level: c_int = 4i32;
 #[unsafe(no_mangle)]
 pub static trace_ext_prefix: &[u8] = b"TA\0";
+/// # Safety
+/// This function is called by the OP-TEE framework to get the trace level.
+/// It's safe to call as it only reads a static variable.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tahead_get_trace_level() -> c_int {
-    unsafe {
-        return trace_level;
-    }
+    unsafe { trace_level }
 }
 static FLAG_BOOL: bool = (TA_FLAGS & optee_utee_sys::TA_FLAG_SINGLE_INSTANCE) != 0;
 static FLAG_MULTI: bool = (TA_FLAGS & optee_utee_sys::TA_FLAG_MULTI_SESSION) != 0;

--- a/optee-utee-build/test_files/test_edition_before_2024_result.rs
+++ b/optee-utee-build/test_files/test_edition_before_2024_result.rs
@@ -27,11 +27,12 @@ const TA_DESCRIPTION: &[u8] = b"test_before_2024\0";
 pub static mut trace_level: c_int = 4i32;
 #[no_mangle]
 pub static trace_ext_prefix: &[u8] = b"TA\0";
+/// # Safety
+/// This function is called by the OP-TEE framework to get the trace level.
+/// It's safe to call as it only reads a static variable.
 #[no_mangle]
 pub unsafe extern "C" fn tahead_get_trace_level() -> c_int {
-    unsafe {
-        return trace_level;
-    }
+    unsafe { trace_level }
 }
 static FLAG_BOOL: bool = (TA_FLAGS & optee_utee_sys::TA_FLAG_SINGLE_INSTANCE) != 0;
 static FLAG_MULTI: bool = (TA_FLAGS & optee_utee_sys::TA_FLAG_MULTI_SESSION) != 0;

--- a/projects/web3/eth_wallet/host/Makefile
+++ b/projects/web3/eth_wallet/host/Makefile
@@ -23,7 +23,6 @@ OBJCOPY := $(CROSS_COMPILE)objcopy
 LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
 
 OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
 all: host strip
 
 host:

--- a/projects/web3/eth_wallet/ta/Cargo.lock
+++ b/projects/web3/eth_wallet/ta/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "ethereum-tx-sign"
 version = "6.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +282,18 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -570,6 +600,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "hashbrown",
  "optee-utee",
  "optee-utee-sys",
  "serde",

--- a/projects/web3/eth_wallet/ta/Makefile
+++ b/projects/web3/eth_wallet/ta/Makefile
@@ -29,9 +29,13 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 OUT_DIR := $(CURDIR)/target/$(TARGET_TA)/release
 
-all: ta strip sign
+all: clippy ta strip sign
 
-ta:
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- -D warnings
+
+ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
 
 strip: ta

--- a/projects/web3/eth_wallet/ta/build.rs
+++ b/projects/web3/eth_wallet/ta/build.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use optee_utee_build::{Error, RustEdition, TaConfig};
-use proto;
 
 fn main() -> Result<(), Error> {
     let ta_config = TaConfig::new_default_with_cargo_env(proto::UUID)?

--- a/projects/web3/eth_wallet/ta/src/wallet.rs
+++ b/projects/web3/eth_wallet/ta/src/wallet.rs
@@ -55,14 +55,11 @@ impl Wallet {
         )
         .into_uuid();
 
-        Ok(Self {
-            id: uuid,
-            entropy: entropy,
-        })
+        Ok(Self { id: uuid, entropy })
     }
 
     pub fn get_id(&self) -> Uuid {
-        self.id.clone()
+        self.id
     }
 
     pub fn get_mnemonic(&self) -> Result<String> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,7 +19,7 @@
 
 [toolchain]
 channel = "nightly-2024-05-15"
-components = [ "rust-src" ]
+components = [ "rust-src", "rustfmt", "clippy" ]
 targets = ["aarch64-unknown-linux-gnu", "arm-unknown-linux-gnueabihf"]
 # minimal profile: install rustc, cargo, and rust-std
 profile = "minimal"


### PR DESCRIPTION
This PR enforces `cargo fmt` and `cargo clippy` for all CAs and TAs in `examples/` and `projects/`.

- The `-D warnings` is added to clippy commands to treat `Rust compiler warnings` and `all default clippy errors` as build failures for **example code**, while dependencies such as `optee-*` crates and `std lib` continue to show warnings without blocking the build.

- Fixes clippy errors in all CAs ad TAs, such as `needless_borrow`, `needless_return`, `needless_range_loop`, `never_loop`, `unused_imports`, and so on.

Future Plan
- Enable clippy checks of building `optee-*` crates in CI and fix clippy errors;
- Add `-D clippy::unwrap_used` enforcement and eliminate all `unwrap()` calls, especially in TAs which should never panic.