### PR TITLE
ci: cleanup unused packages for OP-TEE workflows

### DIFF
--- a/.github/workflows/reuse_test_in_optee_repo.yml
+++ b/.github/workflows/reuse_test_in_optee_repo.yml
@@ -34,15 +34,41 @@ jobs:
   # in OP-TEE repo.
   OPTEE-repo-build-and-run-examples-64bit-TAs:
     runs-on: ${{ inputs.runs-on }}
-    container: ${{ inputs.container }}
     steps:
-      - name: Remove /__t/*
-        run: rm -rf /__t/*
+      - name: Cleanup unused packages to free disk space
+        run: |
+          echo "Removing top large packages"
+          packages=(
+            google-chrome-stable microsoft-edge-stable firefox
+            azure-cli google-cloud-cli kubectl podman skopeo buildah snapd
+            temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk
+            dotnet-sdk-8.0 dotnet-runtime-8.0 aspnetcore-runtime-8.0 aspnetcore-targeting-pack-8.0 netstandard-targeting-pack-2.1-8.0 dotnet-targeting-pack-8.0
+            llvm-16-dev llvm-17-dev llvm-18-dev
+            clang-tools-16 clang-tools-17 clang-tools-18
+            clang-tidy-16 clang-tidy-17 clang-tidy-18
+          )
+          for pkg in "${packages[@]}"; do
+              if dpkg-query -W -f='${Package}\n' $pkg 2>/dev/null | grep -q .; then
+                  echo "Package $pkg exists, removing..."
+                  sudo apt-get remove -y --purge --allow-change-held-packages --allow-remove-essential --no-install-recommends $pkg || true
+              else
+                  echo "Package $pkg not found, skipping."
+              fi
+          done
+          sudo apt-get autoremove -y || true
+          sudo apt-get clean || true
+          echo "Disk usage after cleanup:"
+          df -h
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: 'incubator-teaclave-trustzone-sdk'
+      - name: Install OP-TEE dependencies
+        run: |
+          cd $GITHUB_WORKSPACE/incubator-teaclave-trustzone-sdk
+          chmod +x setup_optee_dependencies.sh
+          sudo ./setup_optee_dependencies.sh
       - name: Checkout OP-TEE repository
         run: |
           mkdir -p ~/optee-qemuv8 && cd ~/optee-qemuv8 &&
@@ -61,15 +87,41 @@ jobs:
   # in OP-TEE repo.
   OPTEE-repo-build-and-run-examples-32bit-TAs:
     runs-on: ${{ inputs.runs-on }}
-    container: ${{ inputs.container }}
     steps:
-      - name: Remove /__t/*
-        run: rm -rf /__t/*
+      - name: Cleanup unused packages to free disk space
+        run: |
+          echo "Removing top large packages"
+          packages=(
+            google-chrome-stable microsoft-edge-stable firefox
+            azure-cli google-cloud-cli kubectl podman skopeo buildah snapd
+            temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-21-jdk
+            dotnet-sdk-8.0 dotnet-runtime-8.0 aspnetcore-runtime-8.0 aspnetcore-targeting-pack-8.0 netstandard-targeting-pack-2.1-8.0 dotnet-targeting-pack-8.0
+            llvm-16-dev llvm-17-dev llvm-18-dev
+            clang-tools-16 clang-tools-17 clang-tools-18
+            clang-tidy-16 clang-tidy-17 clang-tidy-18
+          )
+          for pkg in "${packages[@]}"; do
+              if dpkg-query -W -f='${Package}\n' $pkg 2>/dev/null | grep -q .; then
+                  echo "Package $pkg exists, removing..."
+                  sudo apt-get remove -y --purge --allow-change-held-packages --allow-remove-essential --no-install-recommends $pkg || true
+              else
+                  echo "Package $pkg not found, skipping."
+              fi
+          done
+          sudo apt-get autoremove -y || true
+          sudo apt-get clean || true
+          echo "Disk usage after cleanup:"
+          df -h
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           path: 'incubator-teaclave-trustzone-sdk'
+      - name: Install OP-TEE dependencies
+        run: |
+          cd $GITHUB_WORKSPACE/incubator-teaclave-trustzone-sdk
+          chmod +x setup_optee_dependencies.sh
+          sudo ./setup_optee_dependencies.sh
       - name: Checkout OP-TEE repository
         run: |
           mkdir -p ~/optee-qemuv8 && cd ~/optee-qemuv8 &&


### PR DESCRIPTION
- Remove unused packages from the host machine, freeing approximately 15 GB of disk space.

- Build directly on the host machine instead of using a container. Seems the container only installed OP-TEE dependencies https://github.com/apache/incubator-teaclave-trustzone-sdk/blob/main/Dockerfile, which can now be handled directly on the host. Running everything on the host avoids unnecessary switching between host and container environments.

Since the CI is not triggered for PRs, you can see it passed on my fork: https://github.com/DemesneGH/rust-optee-trustzone-sdk 