### PR TITLE
examples: advanced clippy enforcement to avoid panic

### DIFF
--- a/examples/acipher-rs/host/Makefile
+++ b/examples/acipher-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings
+	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/aes-rs/host/Makefile
+++ b/examples/aes-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/aes-rs/host/src/main.rs
+++ b/examples/aes-rs/host/src/main.rs
@@ -76,7 +76,7 @@ fn cipher_buffer(
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     let key = [0xa5u8; AES_TEST_KEY_SIZE];

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/aes-rs/ta/src/main.rs
+++ b/examples/aes-rs/ta/src/main.rs
@@ -28,7 +28,7 @@ use optee_utee::{
 };
 use optee_utee::{AlgorithmId, Cipher, ElementId, OperationMode};
 use optee_utee::{AttributeId, AttributeMemref, TransientObject, TransientObjectType};
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::{Algo, Command, KeySize, Mode};
 
 pub struct AesCipher {
@@ -77,7 +77,7 @@ fn invoke_command(sess_ctx: &mut AesCipher, cmd_id: u32, params: &mut Parameters
         Command::SetKey => set_aes_key(sess_ctx, params),
         Command::SetIV => reset_aes_iv(sess_ctx, params),
         Command::Cipher => cipher_buffer(sess_ctx, params),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 
@@ -86,14 +86,14 @@ pub fn ta2tee_algo_id(algo_id: u32) -> Result<AlgorithmId> {
         Algo::ECB => Ok(AlgorithmId::AesEcbNopad),
         Algo::CBC => Ok(AlgorithmId::AesCbcNopad),
         Algo::CTR => Ok(AlgorithmId::AesCtr),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 
 pub fn ta2tee_key_size(key_sz: u32) -> Result<usize> {
     match KeySize::from(key_sz) {
         KeySize::Bit128 | KeySize::Bit256 => Ok(key_sz as usize),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 
@@ -101,30 +101,29 @@ pub fn ta2tee_mode_id(mode: u32) -> Result<OperationMode> {
     match Mode::from(mode) {
         Mode::Encode => Ok(OperationMode::Encrypt),
         Mode::Decode => Ok(OperationMode::Decrypt),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 
 pub fn alloc_resources(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> {
-    let algo_value = unsafe { params.0.as_value().unwrap().a() };
-    let key_size_value = unsafe { params.1.as_value().unwrap().a() };
-    let mode_id_value = unsafe { params.2.as_value().unwrap().a() };
+    let algo_value = unsafe { params.0.as_value()?.a() };
+    let key_size_value = unsafe { params.1.as_value()?.a() };
+    let mode_id_value = unsafe { params.2.as_value()?.a() };
 
-    aes.key_size = ta2tee_key_size(key_size_value).unwrap();
+    aes.key_size = ta2tee_key_size(key_size_value)?;
 
     // check whether the algorithm is supported
     is_algorithm_supported(
-        ta2tee_algo_id(algo_value).unwrap() as u32,
+        ta2tee_algo_id(algo_value)? as u32,
         ElementId::ElementNone as u32,
     )?;
 
     aes.cipher = Cipher::allocate(
-        ta2tee_algo_id(algo_value).unwrap(),
-        ta2tee_mode_id(mode_id_value).unwrap(),
+        ta2tee_algo_id(algo_value)?,
+        ta2tee_mode_id(mode_id_value)?,
         aes.key_size * 8,
-    )
-    .unwrap();
-    aes.key_object = TransientObject::allocate(TransientObjectType::Aes, aes.key_size * 8).unwrap();
+    )?;
+    aes.key_object = TransientObject::allocate(TransientObjectType::Aes, aes.key_size * 8)?;
     let key = vec![0u8; aes.key_size];
     let attr = AttributeMemref::from_ref(AttributeId::SecretValue, &key);
     aes.key_object.populate(&[attr.into()])?;
@@ -133,12 +132,12 @@ pub fn alloc_resources(aes: &mut AesCipher, params: &mut Parameters) -> Result<(
 }
 
 pub fn set_aes_key(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> {
-    let mut param0 = unsafe { params.0.as_memref().unwrap() };
+    let mut param0 = unsafe { params.0.as_memref()? };
     let key = param0.buffer();
 
     if key.len() != aes.key_size {
         trace_println!("[+] Get wrong key size !\n");
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     let attr = AttributeMemref::from_ref(AttributeId::SecretValue, key);
@@ -151,7 +150,7 @@ pub fn set_aes_key(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> {
 }
 
 pub fn reset_aes_iv(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> {
-    let mut param0 = unsafe { params.0.as_memref().unwrap() };
+    let mut param0 = unsafe { params.0.as_memref()? };
     let iv = param0.buffer();
 
     aes.cipher.init(iv);
@@ -161,19 +160,19 @@ pub fn reset_aes_iv(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> 
 }
 
 pub fn cipher_buffer(aes: &mut AesCipher, params: &mut Parameters) -> Result<()> {
-    let mut param0 = unsafe { params.0.as_memref().unwrap() };
-    let mut param1 = unsafe { params.1.as_memref().unwrap() };
+    let mut param0 = unsafe { params.0.as_memref()? };
+    let mut param1 = unsafe { params.1.as_memref()? };
 
     let input = param0.buffer();
     let output = param1.buffer();
 
     if output.len() < input.len() {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     trace_println!("[+] TA tries to update ciphers!");
 
-    let tmp_size = aes.cipher.update(input, output).unwrap();
+    let tmp_size = aes.cipher.update(input, output)?;
     param1.set_updated_size(tmp_size);
     Ok(())
 }

--- a/examples/authentication-rs/host/Makefile
+++ b/examples/authentication-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/authentication-rs/host/src/main.rs
+++ b/examples/authentication-rs/host/src/main.rs
@@ -79,7 +79,7 @@ fn decrypt_final(
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     let key = [0xa5u8; KEY_SIZE];

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/big_int-rs/host/Makefile
+++ b/examples/big_int-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/big_int-rs/host/src/main.rs
+++ b/examples/big_int-rs/host/src/main.rs
@@ -42,7 +42,7 @@ fn big_int(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     big_int(&mut session)?;

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/big_int-rs/ta/src/main.rs
+++ b/examples/big_int-rs/ta/src/main.rs
@@ -22,7 +22,7 @@ use optee_utee::BigInt;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 #[ta_create]
@@ -60,9 +60,9 @@ fn convert(n0: &BigInt, n1: &BigInt) -> Result<()> {
     trace_println!(
         "{} in u8 array is {:x?}.",
         n0,
-        n0.convert_to_octet_string().unwrap()
+        n0.convert_to_octet_string()?
     );
-    trace_println!("{} in i32 is {}.", n1, n1.convert_to_s32().unwrap());
+    trace_println!("{} in i32 is {}.", n1, n1.convert_to_s32()?);
     Ok(())
 }
 
@@ -99,8 +99,8 @@ fn module(n0: &BigInt, n1: &BigInt) -> Result<()> {
 #[ta_invoke_command]
 fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
-    let mut n0_buffer = unsafe { params.0.as_memref().unwrap() };
-    let n1_value = unsafe { params.1.as_value().unwrap() };
+    let mut n0_buffer = unsafe { params.0.as_memref()? };
+    let n1_value = unsafe { params.1.as_value()? };
 
     let mut n0 = BigInt::new(64);
     let mut n1 = BigInt::new(2);
@@ -116,7 +116,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
         Command::Multiply => multiply(&n0, &n1),
         Command::Divide => divide(&n0, &n1),
         Command::Module => module(&n0, &n1),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/build_with_optee_utee_sys-rs/host/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG) -vv

--- a/examples/build_with_optee_utee_sys-rs/ta/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/build_with_optee_utee_sys-rs/ta/src/main.rs
+++ b/examples/build_with_optee_utee_sys-rs/ta/src/main.rs
@@ -22,7 +22,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 static GLOBAL_VALUE: AtomicU32 = AtomicU32::new(0);
@@ -61,7 +61,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             values.set_a(result);
             Ok(())
         }
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/client_pool-rs/host/Makefile
+++ b/examples/client_pool-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/client_pool-rs/ta/Makefile
+++ b/examples/client_pool-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/diffie_hellman-rs/host/Makefile
+++ b/examples/diffie_hellman-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/diffie_hellman-rs/host/src/main.rs
+++ b/examples/diffie_hellman-rs/host/src/main.rs
@@ -66,11 +66,11 @@ fn derive_key(key0_pub: &Vec<u8>, session: &mut Session) -> Result<()> {
 
 fn main() -> Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
-    let (key0_public, key0_private) = generate_key(&mut session).unwrap();
-    let (key1_public, key1_private) = generate_key(&mut session).unwrap();
+    let (key0_public, key0_private) = generate_key(&mut session)?;
+    let (key1_public, key1_private) = generate_key(&mut session)?;
     println!(
         "get key 0 pair as public: {:?}, private: {:?}",
         key0_public, key0_private

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/digest-rs/host/Makefile
+++ b/examples/digest-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/digest-rs/host/src/main.rs
+++ b/examples/digest-rs/host/src/main.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use optee_teec::ErrorKind;
 use optee_teec::{
     Context, Operation, ParamNone, ParamTmpRef, ParamType, ParamValue, Session, Uuid,
 };
-use optee_teec::{Error, ErrorKind};
 use proto::{Command, UUID};
 use std::env;
 
@@ -47,11 +47,11 @@ fn main() -> optee_teec::Result<()> {
     if args_len < 2 {
         println!("Do not receive any message for digest.");
         println!("Correct usage: passed more than 1 argument as <part_of_message>");
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
 
     let mut hash: [u8; 32] = [0u8; 32];
     let mut session = ctx.open_session(uuid)?;
@@ -60,7 +60,7 @@ fn main() -> optee_teec::Result<()> {
         update(&mut session, arg.as_bytes())?;
     }
 
-    let hash_length = do_final(&mut session, args[args_len - 1].as_bytes(), &mut hash).unwrap();
+    let hash_length = do_final(&mut session, args[args_len - 1].as_bytes(), &mut hash)?;
     let mut res = hash.to_vec();
     res.truncate(hash_length as usize);
 

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/error_handling-rs/host/Makefile
+++ b/examples/error_handling-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/error_handling-rs/host/src/main.rs
+++ b/examples/error_handling-rs/host/src/main.rs
@@ -16,18 +16,20 @@
 // under the License.
 
 use optee_teec::ParamNone;
-use optee_teec::{Context, ErrorKind, Operation, Uuid};
+use optee_teec::{Context, ErrorKind, Operation, Result, Uuid};
 use proto::{Command, UUID};
 
-fn main() -> optee_teec::Result<()> {
-    test_error_handling();
-    Ok(())
+fn main() -> Result<()> {
+    test_error_handling()
 }
 
-fn test_error_handling() {
-    let mut ctx = Context::new().unwrap();
-    let uuid = Uuid::parse_str(UUID).unwrap();
-    let mut session = ctx.open_session(uuid).unwrap();
+// NOTE: This seems to be a test case, not an example. Temporarily allow the expect
+// here and the reorganization is planned for this kind of test cases.
+#[allow(clippy::expect_used)]
+fn test_error_handling() -> Result<()> {
+    let mut ctx = Context::new()?;
+    let uuid = Uuid::parse_str(UUID)?;
+    let mut session = ctx.open_session(uuid)?;
     let mut operation = Operation::new(0, ParamNone, ParamNone, ParamNone, ParamNone);
 
     // Test successful invocation return Ok().
@@ -48,4 +50,5 @@ fn test_error_handling() {
     assert_eq!(e.kind(), ErrorKind::Generic);
 
     println!("Test passed");
+    Ok(())
 }

--- a/examples/error_handling-rs/ta/Makefile
+++ b/examples/error_handling-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/error_handling-rs/ta/src/main.rs
+++ b/examples/error_handling-rs/ta/src/main.rs
@@ -27,7 +27,7 @@ use alloc::vec::Vec;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 pub struct SessionContext {
@@ -73,8 +73,8 @@ fn invoke_command(
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
         Command::ReturnSuccess => Ok(()),
-        Command::ReturnGenericError => Err(Error::new(ErrorKind::Generic)),
-        _ => Err(Error::new(ErrorKind::NotSupported)),
+        Command::ReturnGenericError => Err(ErrorKind::Generic.into()),
+        _ => Err(ErrorKind::NotSupported.into()),
     }
 }
 

--- a/examples/hello_world-rs/host/Makefile
+++ b/examples/hello_world-rs/host/Makefile
@@ -29,7 +29,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings
+	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/hello_world-rs/host/src/main.rs
+++ b/examples/hello_world-rs/host/src/main.rs
@@ -35,7 +35,7 @@ fn hello_world(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     hello_world(&mut session)?;

--- a/examples/hello_world-rs/ta/Cargo.toml
+++ b/examples/hello_world-rs/ta/Cargo.toml
@@ -34,6 +34,5 @@ proto = { path = "../proto" }
 optee-utee-build = { path = "../../../optee-utee-build" }
 
 [profile.release]
-panic = "abort"
 lto = true
 opt-level = 1

--- a/examples/hello_world-rs/ta/Makefile
+++ b/examples/hello_world-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/hello_world-rs/ta/src/main.rs
+++ b/examples/hello_world-rs/ta/src/main.rs
@@ -21,7 +21,7 @@
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 #[ta_create]
@@ -49,7 +49,7 @@ fn destroy() {
 #[ta_invoke_command]
 fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
-    let mut values = unsafe { params.0.as_value().unwrap() };
+    let mut values = unsafe { params.0.as_value()? };
     match Command::from(cmd_id) {
         Command::IncValue => {
             values.set_a(values.a() + 100);
@@ -59,7 +59,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             values.set_a(values.a() - 100);
             Ok(())
         }
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/hotp-rs/host/Makefile
+++ b/examples/hotp-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/hotp-rs/host/src/main.rs
+++ b/examples/hotp-rs/host/src/main.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use optee_teec::{
-    Context, Error, ErrorKind, Operation, ParamNone, ParamTmpRef, ParamType, ParamValue, Session,
-    Uuid,
+    Context, ErrorKind, Operation, ParamNone, ParamTmpRef, ParamType, ParamValue, Session, Uuid,
 };
 use proto::{Command, UUID};
 
@@ -53,7 +52,7 @@ fn get_hotp(session: &mut Session) -> optee_teec::Result<()> {
 
         if hotp_value != expected_value {
             println!("Wrong value get! Expected value: {}", expected_value);
-            return Err(Error::new(ErrorKind::Generic));
+            return Err(ErrorKind::Generic.into());
         }
     }
     Ok(())
@@ -61,7 +60,7 @@ fn get_hotp(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     register_shared_key(&mut session)?;

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/inter_ta-rs/host/Makefile
+++ b/examples/inter_ta-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/inter_ta-rs/ta/Makefile
+++ b/examples/inter_ta-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/message_passing_interface-rs/host/Makefile
+++ b/examples/message_passing_interface-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/message_passing_interface-rs/ta/Makefile
+++ b/examples/message_passing_interface-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings
+	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/mnist-rs/host/Makefile
+++ b/examples/mnist-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/mnist-rs/host/src/commands/infer.rs
+++ b/examples/mnist-rs/host/src/commands/infer.rs
@@ -55,7 +55,7 @@ pub fn execute(args: &Args) -> anyhow::Result<()> {
         .image
         .iter()
         .map(|v| {
-            let img = image::open(v).unwrap().to_luma8();
+            let img = image::open(v)?.to_luma8();
             let bytes = img.as_bytes();
             anyhow::ensure!(bytes.len() == IMAGE_SIZE);
             TryInto::<Image>::try_into(bytes)

--- a/examples/mnist-rs/ta/inference/Makefile
+++ b/examples/mnist-rs/ta/inference/Makefile
@@ -35,7 +35,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)

--- a/examples/mnist-rs/ta/train/Makefile
+++ b/examples/mnist-rs/ta/train/Makefile
@@ -35,7 +35,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)

--- a/examples/property-rs/host/Makefile
+++ b/examples/property-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/property-rs/ta/Makefile
+++ b/examples/property-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/property-rs/ta/src/main.rs
+++ b/examples/property-rs/ta/src/main.rs
@@ -28,7 +28,7 @@ use optee_utee::LoginType;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 #[ta_create]
@@ -63,11 +63,11 @@ fn get_properties() -> Result<()> {
     );
     // login type should be Public
     if client_identity.login_type() != LoginType::Public {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
     // uuid should be all zero
     if client_identity.uuid().to_string() != "00000000-0000-0000-0000-000000000000" {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     // test the other property:
@@ -75,21 +75,21 @@ fn get_properties() -> Result<()> {
     trace_println!("[+] TA get core version: {}", core_version);
     // core version should not be zero
     if core_version == 0 {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     let ta_multi_session = TaMultiSession.get()?;
     trace_println!("[+] TA get multi session: {}", ta_multi_session);
     // multi session should be false
     if ta_multi_session {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     let ta_description = TaDescription.get()?;
     trace_println!("[+] TA get description: {}", ta_description);
     // description should be the specified string
     if ta_description != "An example of Rust OP-TEE TrustZone SDK." {
-        return Err(Error::new(ErrorKind::BadParameters));
+        return Err(ErrorKind::BadParameters.into());
     }
 
     Ok(())
@@ -105,7 +105,7 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             trace_println!("[+] Test passed");
             Ok(())
         }
-        _ => Err(Error::new(ErrorKind::NotSupported)),
+        _ => Err(ErrorKind::NotSupported.into()),
     }
 }
 

--- a/examples/random-rs/host/Makefile
+++ b/examples/random-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/random-rs/host/src/main.rs
+++ b/examples/random-rs/host/src/main.rs
@@ -28,7 +28,7 @@ fn random(session: &mut Session) -> optee_teec::Result<()> {
     session.invoke_command(Command::RandomGenerator as u32, &mut operation)?;
     println!("Invoking done!");
 
-    let generate_uuid = Uuid::from_slice(&random_uuid).unwrap();
+    let generate_uuid = Uuid::from_slice(&random_uuid)?;
 
     println!("Generate random UUID: {}", generate_uuid);
     Ok(())
@@ -37,7 +37,7 @@ fn random(session: &mut Session) -> optee_teec::Result<()> {
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
 
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     random(&mut session)?;

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/random-rs/ta/src/main.rs
+++ b/examples/random-rs/ta/src/main.rs
@@ -25,7 +25,7 @@ use optee_utee::Random;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 #[ta_create]
@@ -51,7 +51,7 @@ fn destroy() {
 }
 
 pub fn random_number_generate(params: &mut Parameters) -> Result<()> {
-    let mut p = unsafe { params.0.as_memref().unwrap() };
+    let mut p = unsafe { params.0.as_memref()? };
     let mut buf = vec![0; p.buffer().len()];
     buf.copy_from_slice(p.buffer());
 
@@ -66,7 +66,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
     trace_println!("[+] TA invoke command");
     match Command::from(cmd_id) {
         Command::RandomGenerator => random_number_generate(params),
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/secure_db_abstraction-rs/host/Makefile
+++ b/examples/secure_db_abstraction-rs/host/Makefile
@@ -30,7 +30,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/secure_db_abstraction-rs/ta/Makefile
+++ b/examples/secure_db_abstraction-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings
+	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/secure_db_abstraction-rs/ta/src/main.rs
+++ b/examples/secure_db_abstraction-rs/ta/src/main.rs
@@ -23,7 +23,7 @@ use alloc::vec;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 use secure_db::{SecureStorageClient, Storable};
 use serde::{Deserialize, Serialize};
@@ -61,10 +61,10 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             }
             Err(e) => {
                 trace_println!("[-] Test failed: {:?}", e);
-                Err(Error::new(ErrorKind::Generic))
+                Err(ErrorKind::Generic.into())
             }
         },
-        _ => Err(Error::new(ErrorKind::NotSupported)),
+        _ => Err(ErrorKind::NotSupported.into()),
     }
 }
 

--- a/examples/secure_storage-rs/host/Makefile
+++ b/examples/secure_storage-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/secure_storage-rs/host/src/main.rs
+++ b/examples/secure_storage-rs/host/src/main.rs
@@ -63,10 +63,15 @@ fn delete_secure_object(session: &mut Session, obj_id: &[u8]) -> optee_teec::Res
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
-    let obj1_id = CString::new("object#1").unwrap().into_bytes_with_nul();
+    let obj1_id = CString::new("object#1")
+        .map_err(|e| {
+            eprintln!("Failed to create CString for object#1: {}", e);
+            ErrorKind::BadParameters
+        })?
+        .into_bytes_with_nul();
     let obj1_data = [0xA1u8; TEST_OBJECT_SIZE];
     let mut read_data = [0x00u8; TEST_OBJECT_SIZE];
 
@@ -81,7 +86,12 @@ fn main() -> optee_teec::Result<()> {
     }
     delete_secure_object(&mut session, &obj1_id)?;
 
-    let obj2_id = CString::new("object#2").unwrap().into_bytes_with_nul();
+    let obj2_id = CString::new("object#2")
+        .map_err(|e| {
+            eprintln!("Failed to create CString for object#2: {}", e);
+            ErrorKind::BadParameters
+        })?
+        .into_bytes_with_nul();
 
     println!("\nTest on object \"object#2\"");
     match read_secure_object(&mut session, obj2_id.as_slice(), &mut read_data) {

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/serde-rs/host/Makefile
+++ b/examples/serde-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/serde-rs/ta/Makefile
+++ b/examples/serde-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings
+	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/signature_verification-rs/host/Makefile
+++ b/examples/signature_verification-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/signature_verification-rs/host/src/main.rs
+++ b/examples/signature_verification-rs/host/src/main.rs
@@ -57,7 +57,7 @@ fn verify(
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     let message: &[u8] = b"hello,world";

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/supp_plugin-rs/host/Makefile
+++ b/examples/supp_plugin-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/supp_plugin-rs/plugin/Cargo.toml
+++ b/examples/supp_plugin-rs/plugin/Cargo.toml
@@ -32,6 +32,7 @@ optee-teec = { path = "../../../optee-teec" }
 [build-dependencies]
 uuid = { version = "0.8" }
 proto = { path = "../proto" }
+anyhow = "1.0"
 
 [profile.release]
 lto = true

--- a/examples/supp_plugin-rs/plugin/Makefile
+++ b/examples/supp_plugin-rs/plugin/Makefile
@@ -29,7 +29,7 @@ all: clippy host
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings
+	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/supp_plugin-rs/plugin/build.rs
+++ b/examples/supp_plugin-rs/plugin/build.rs
@@ -15,18 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use anyhow::{anyhow, Result};
 use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use uuid::Uuid;
 
-fn main() -> std::io::Result<()> {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+fn main() -> Result<()> {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").ok_or_else(|| anyhow!("OUT_DIR not set"))?);
     let mut buffer = File::create(out.join("plugin_static.rs"))?;
     buffer.write_all(include_bytes!("plugin_static.rs"))?;
 
-    let plugin_uuid = Uuid::parse_str(proto::PLUGIN_UUID).unwrap();
+    let plugin_uuid = Uuid::parse_str(proto::PLUGIN_UUID)?;
     let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = plugin_uuid.as_fields();
 
     writeln!(buffer)?;

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/supp_plugin-rs/ta/src/main.rs
+++ b/examples/supp_plugin-rs/ta/src/main.rs
@@ -58,10 +58,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
         "[+] TA received value {:?} then send to plugin",
         p0.buffer()
     );
-    let uuid = Uuid::parse_str(PLUGIN_UUID).map_err(|err| {
-        trace_println!("Invalid PluginUuid: {:?}", err);
-        ErrorKind::BadParameters
-    })?;
+    let uuid = Uuid::parse_str(PLUGIN_UUID)?;
 
     match Command::from(cmd_id) {
         Command::Ping => {

--- a/examples/tcp_client-rs/host/Makefile
+++ b/examples/tcp_client-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/tcp_client-rs/ta/Makefile
+++ b/examples/tcp_client-rs/ta/Makefile
@@ -42,7 +42,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)

--- a/examples/tcp_client-rs/ta/src/main.rs
+++ b/examples/tcp_client-rs/ta/src/main.rs
@@ -41,7 +41,7 @@ use optee_utee::net::TcpStream;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::{Command, IpVersion};
 
 #[ta_create]
@@ -77,15 +77,20 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             let param1 = unsafe { params.1.as_value()? };
             let mut param2 = unsafe { params.2.as_memref()? };
 
-            let address = core::str::from_utf8(param0.buffer()).unwrap();
+            let address = core::str::from_utf8(param0.buffer()).map_err(|e| {
+                trace_println!("Failed to parse address from UTF-8: {}", e);
+                ErrorKind::BadParameters
+            })?;
             let port = param1.a() as u16;
-            let ip_version =
-                IpVersion::try_from(param1.b()).map_err(|_| ErrorKind::BadParameters)?;
+            let ip_version = IpVersion::try_from(param1.b()).map_err(|_| {
+                trace_println!("Invalid IP version parameter");
+                ErrorKind::BadParameters
+            })?;
             let http_data = param2.buffer();
 
             tcp_client(address, port, ip_version, http_data)
         }
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/time-rs/host/Makefile
+++ b/examples/time-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/time-rs/host/src/main.rs
+++ b/examples/time-rs/host/src/main.rs
@@ -29,7 +29,7 @@ fn time(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     time(&mut session)?;

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -37,7 +37,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/time-rs/ta/src/main.rs
+++ b/examples/time-rs/ta/src/main.rs
@@ -22,7 +22,7 @@ use optee_utee::Time;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 #[ta_create]
@@ -55,7 +55,7 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             time()?;
             Ok(())
         }
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/tls_client-rs/host/Makefile
+++ b/examples/tls_client-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/tls_client-rs/host/src/main.rs
+++ b/examples/tls_client-rs/host/src/main.rs
@@ -27,7 +27,7 @@ fn tls_client(session: &mut Session) -> optee_teec::Result<()> {
 
 fn main() -> optee_teec::Result<()> {
     let mut ctx = Context::new()?;
-    let uuid = Uuid::parse_str(UUID).unwrap();
+    let uuid = Uuid::parse_str(UUID)?;
     let mut session = ctx.open_session(uuid)?;
 
     tls_client(&mut session)?;

--- a/examples/tls_client-rs/ta/Makefile
+++ b/examples/tls_client-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings
+	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/tls_client-rs/ta/src/main.rs
+++ b/examples/tls_client-rs/ta/src/main.rs
@@ -22,7 +22,7 @@ use optee_utee::net::TcpStream;
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 use rustls::RootCertStore;
 use std::convert::TryInto;
@@ -72,10 +72,10 @@ fn invoke_command(cmd_id: u32, _params: &mut Parameters) -> Result<()> {
             }
             Err(e) => {
                 trace_println!("[-] TLS client failed: {:?}", e);
-                Err(Error::new(ErrorKind::Generic))
+                Err(ErrorKind::Generic.into())
             }
         },
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/tls_server-rs/host/Makefile
+++ b/examples/tls_server-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/tls_server-rs/ta/Makefile
+++ b/examples/tls_server-rs/ta/Makefile
@@ -33,7 +33,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings
+	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)

--- a/examples/tls_server-rs/ta/src/main.rs
+++ b/examples/tls_server-rs/ta/src/main.rs
@@ -20,7 +20,7 @@
 use optee_utee::{
     ta_close_session, ta_create, ta_destroy, ta_invoke_command, ta_open_session, trace_println,
 };
-use optee_utee::{Error, ErrorKind, Parameters, Result};
+use optee_utee::{ErrorKind, Parameters, Result};
 use proto::Command;
 
 use anyhow::Context;
@@ -77,7 +77,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             trace_println!("[+] new_tls_session");
             new_tls_session(session_id).map_err(|e| {
                 trace_println!("[-] Failed to create TLS session: {:?}", e);
-                Error::new(ErrorKind::Generic)
+                ErrorKind::Generic.into()
             })
         }
         Command::DoTlsRead => {
@@ -86,7 +86,7 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
             trace_println!("[+] do_tls_read");
             do_tls_read(session_id, buffer).map_err(|e| {
                 trace_println!("[-] Failed to read TLS data: {:?}", e);
-                Error::new(ErrorKind::Generic)
+                ErrorKind::Generic.into()
             })
         }
         Command::DoTlsWrite => {
@@ -100,17 +100,17 @@ fn invoke_command(cmd_id: u32, params: &mut Parameters) -> Result<()> {
                 })
                 .map_err(|e| {
                     trace_println!("[-] Failed to write TLS data: {:?}", e);
-                    Error::new(ErrorKind::Generic)
+                    ErrorKind::Generic.into()
                 })
         }
         Command::CloseTlsSession => {
             trace_println!("[+] close_tls_session");
             close_tls_session(session_id).map_err(|e| {
                 trace_println!("[-] Failed to close TLS session: {:?}", e);
-                Error::new(ErrorKind::Generic)
+                ErrorKind::Generic.into()
             })
         }
-        _ => Err(Error::new(ErrorKind::BadParameters)),
+        _ => Err(ErrorKind::BadParameters.into()),
     }
 }
 

--- a/examples/udp_socket-rs/host/Makefile
+++ b/examples/udp_socket-rs/host/Makefile
@@ -28,7 +28,7 @@ all: clippy host strip
 
 clippy:
 	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings
+	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 host: clippy
 	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)

--- a/examples/udp_socket-rs/ta/Makefile
+++ b/examples/udp_socket-rs/ta/Makefile
@@ -42,7 +42,7 @@ all: clippy ta strip sign
 
 clippy:
 	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
 
 ta: clippy
 	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)

--- a/optee-teec/src/uuid.rs
+++ b/optee-teec/src/uuid.rs
@@ -16,10 +16,9 @@
 // under the License.
 
 use crate::raw;
+use crate::{ErrorKind, Result};
 use core::fmt;
 use uuid as uuid_crate;
-use uuid_crate::parser::ParseError;
-use uuid_crate::BytesError;
 
 /// A Universally Unique Resource Identifier (UUID) type as defined in RFC4122.
 /// The value is used to identify a trusted application.
@@ -34,14 +33,13 @@ impl Uuid {
     ///
     /// ```
     /// # use optee_teec::Uuid;
-    /// # use uuid::parser::ParseError;
-    /// # fn main() -> Result<(), ParseError> {
+    /// # fn main() -> optee_teec::Result<()> {
     /// let uuid = Uuid::parse_str("8abcf200-2450-11e4-abe2-0002a5d5c51b")?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn parse_str(input: &str) -> Result<Uuid, ParseError> {
-        let uuid = uuid_crate::Uuid::parse_str(input)?;
+    pub fn parse_str(input: &str) -> Result<Uuid> {
+        let uuid = uuid_crate::Uuid::parse_str(input).map_err(|_| ErrorKind::BadFormat)?;
         let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = uuid.as_fields();
         Ok(Self::new_raw(
             time_low,
@@ -72,14 +70,14 @@ impl Uuid {
     ///
     /// ```
     /// # use optee_teec::Uuid;
-    /// # fn main() -> Result<(), uuid::BytesError> {
+    /// # fn main() -> optee_teec::Result<()> {
     /// let bytes: &[u8; 16] = &[70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63, 62,];
     /// let uuid = Uuid::from_slice(bytes)?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_slice(b: &[u8]) -> Result<Uuid, BytesError> {
-        let uuid = uuid_crate::Uuid::from_slice(b)?;
+    pub fn from_slice(b: &[u8]) -> Result<Uuid> {
+        let uuid = uuid_crate::Uuid::from_slice(b).map_err(|_| ErrorKind::BadFormat)?;
         let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = uuid.as_fields();
         Ok(Self::new_raw(
             time_low,
@@ -149,9 +147,9 @@ mod tests {
             "11173366-2aca-19bc-beb7-10c975e6131e", // random uuid
         ];
         for origin in uuids.iter() {
-            let uuid = Uuid::parse_str(origin);
-            let formatted = uuid.map(|x| x.to_string());
-            assert_eq!(Ok(origin.to_string()), formatted);
+            let uuid = Uuid::parse_str(origin).expect("Test UUID should be valid");
+            let formatted = uuid.to_string();
+            assert_eq!(*origin, formatted);
         }
     }
 }

--- a/optee-utee/src/uuid.rs
+++ b/optee-utee/src/uuid.rs
@@ -19,6 +19,7 @@ use core::fmt;
 use hex;
 use optee_utee_sys as raw;
 use uuid as uuid_crate;
+use crate::{ErrorKind, Result};
 
 /// A Universally Unique Resource Identifier (UUID) type as defined in RFC4122.
 /// The value is used to identify a trusted application.
@@ -34,14 +35,14 @@ impl Uuid {
     ///
     /// ``` rust,no_run
     /// # use optee_utee::Uuid;
-    /// # fn main() -> Result<(), uuid::Error> {
+    /// # fn main() -> optee_utee::Result<()> {
     ///
     /// let uuid = Uuid::parse_str("8abcf200-2450-11e4-abe2-0002a5d5c51b")?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn parse_str(input: &str) -> Result<Uuid, uuid_crate::Error> {
-        let uuid = uuid_crate::Uuid::parse_str(input)?;
+    pub fn parse_str(input: &str) -> Result<Uuid> {
+        let uuid = uuid_crate::Uuid::parse_str(input).map_err(|_| ErrorKind::BadFormat)?;
         let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = uuid.as_fields();
         Ok(Self::new_raw(
             time_low,
@@ -72,14 +73,14 @@ impl Uuid {
     ///
     /// ``` rust,no_run
     /// # use optee_utee::Uuid;
-    /// # fn main() -> Result<(), uuid::Error> {
+    /// # fn main() -> optee_utee::Result<()> {
     /// let bytes: &[u8; 16] = &[70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63, 62,];
     /// let uuid = Uuid::from_slice(bytes)?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_slice(b: &[u8]) -> Result<Uuid, uuid_crate::Error> {
-        let uuid = uuid_crate::Uuid::from_slice(b)?;
+    pub fn from_slice(b: &[u8]) -> Result<Uuid> {
+        let uuid = uuid_crate::Uuid::from_slice(b).map_err(|_| ErrorKind::BadFormat)?;
         let (time_low, time_mid, time_hi_and_version, clock_seq_and_node) = uuid.as_fields();
         Ok(Self::new_raw(
             time_low,
@@ -146,9 +147,9 @@ mod tests {
             "11173366-2aca-19bc-beb7-10c975e6131e", // random uuid
         ];
         for origin in uuids.iter() {
-            let uuid = Uuid::parse_str(origin);
-            let formatted = uuid.map(|x| x.to_string());
-            assert_eq!(Ok(origin.to_string()), formatted);
+            let uuid = Uuid::parse_str(origin).expect("Test UUID should be valid");
+            let formatted = uuid.to_string();
+            assert_eq!(*origin, formatted);
         }
     }
 }


### PR DESCRIPTION
This PR enforces `-D clippy::unwrap_used -D clippy::expect_used -D clippy::panic` for all examples and fixes the resulting Clippy errors.


Most issues were resolved by replacing `unwrap()` with the `?` operator. A few special cases required additional changes:

* **UUID error handling**:
  Modified `uuid.rs` in `optee-teec` and `optee-utee` to return `optee-*::Error` instead of `uuid::parser::ParseError`. Since `uuid.rs` belongs to the `optee-*` crates, it is more consistent to return the same `Result` type as other modules. This also eliminates many `unwrap()` calls when parsing UUIDs in hosts and TAs.

* **Simplified error returns**:
  Leveraged existing conversion 

    ```
    impl From<ErrorKind> for Error {
        #[inline]
        fn from(kind: ErrorKind) -> Error {
            Error { kind, origin: None }
        }
    }
    ``` 
    
    to simplify error handling (if the Error doesn't specify `origin`), e.g.:

  * `.ok_or(Error::new(ErrorKind::BadParameters))?;` → `.ok_or(ErrorKind::BadParameters)?;`
  * `return Err(Error::new(ErrorKind::Generic));` → `return Err(ErrorKind::Generic.into());`

* **Testcase exceptions**:
  Allowed `expect` in test-related code, such as `uuid.rs` in `optee-*` and `examples/error_handling-rs/host` (which behaves more like a testcase than an example).

----
**Clippy Enforcement Plan**
1. [DONE] All examples: enable default Clippy + compiler checks ([[#224](https://github.com/apache/teaclave-trustzone-sdk/pull/224)](https://github.com/apache/teaclave-trustzone-sdk/pull/224)).
2. All examples: enable advanced panic checks (this PR).
3. [TODO] `optee-*` crates: enable default Clippy checks.
4. [TODO]`optee-*` crates: enable advanced Clippy checks.

