### PR TITLE
ci: remove env HOME from dev docker workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: teaclave/teaclave-trustzone-emulator-nostd-optee-4.7.0-expand-memory:latest
-    env:
-      HOME: /root
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -89,8 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: teaclave/teaclave-trustzone-emulator-std-optee-4.7.0-expand-memory:latest
-    env:
-      HOME: /root
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR finalizes the cleanup of the dev docker workflows by removing the dependency on the `HOME` environment variable.

Summary:

1. The first stage of cleanup: https://github.com/apache/teaclave-trustzone-sdk/pull/236, but the HOME variable remained due to the current dev Docker design.

2. The Docker image was then adjusted as a prerequisite for the final CI cleanup in:https://github.com/apache/teaclave-trustzone-sdk/pull/237.

3. This PR removes the `HOME` environment variable entirely.