### PR TITLE
rust-toolchain.toml: update to nightly-2024-09-01

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -18,7 +18,7 @@
 # Toolchain override for rustup
 
 [toolchain]
-channel = "nightly-2024-05-15"
+channel = "nightly-2024-09-01"
 components = [ "rust-src", "rustfmt", "clippy" ]
 targets = ["aarch64-unknown-linux-gnu", "arm-unknown-linux-gnueabihf"]
 # minimal profile: install rustc, cargo, and rust-std


### PR DESCRIPTION
OP-TEE OS CI fails with:

 2025-10-20T11:28:21.2233057Z Configuring OP-TEE rust examples
 2025-10-20T11:28:21.2756543Z info: syncing channel updates for 'nightly-2024-05-15-x86_64-unknown-linux-gnu'
 2025-10-20T11:28:21.5346002Z info: latest update on 2024-05-15, rust version 1.80.0-nightly (8387315ab 2024-05-14)
 [...]
 2025-10-20T11:28:40.6270531Z info: the active toolchain `nightly-2024-05-15-x86_64-unknown-linux-gnu` has been installed
 [...]
 2025-10-20T11:28:40.6272025Z info: it's active because: overridden by '/__w/optee_os/optee_repo_qemu_v8/out-br/build/optee_rust_examples_ext-1.0/rust-toolchain.toml'
 [...]
 2025-10-20T11:29:09.7985247Z error: rustc 1.80.0-nightly is not supported by the following package:
 2025-10-20T11:29:09.7986356Z   indexmap@2.12.0 requires rustc 1.82
 2025-10-20T11:29:09.7987348Z Either upgrade rustc or select compatible dependency versions with
 2025-10-20T11:29:09.7988205Z `cargo update <name>@<current-ver> --precise <compatible-ver>`
 2025-10-20T11:29:09.7989948Z where `<compatible-ver>` is the latest version supporting rustc 1.80.0-nightly
 2025-10-20T11:29:09.7990396Z
 2025-10-20T11:29:09.8016719Z make[5]: *** [Makefile:31: host] Error 101
 2025-10-20T11:29:09.8021811Z make[4]: *** [Makefile:30: host] Error 2
 2025-10-20T11:29:09.8024793Z make[3]: *** [Makefile:60: examples/acipher-rs] Error 2

Let's upgrade to nightly-2024-09-01 which provides rustc version 1.82.0-nightly (a7399ba69 2024-08-31) and fixes the issue.