### PR TITLE
optee-teec: disable default features for num_enum

### DIFF
--- a/optee-teec/Cargo.toml
+++ b/optee-teec/Cargo.toml
@@ -29,7 +29,7 @@ optee-teec-sys = { version = "0.6.0", path = "optee-teec-sys" }
 optee-teec-macros = { version = "0.6.0", path = "macros" }
 uuid = "0.7"
 hex = "0.3"
-num_enum = "0.7.3"
+num_enum = { version = "0.7.3", default-features = false }
 
 [dev-dependencies]
 # disable linking when running unit tests


### PR DESCRIPTION
Workaround for this error:
```
error: rustc 1.80.0-nightly is not supported by the following package:
  indexmap@2.12.0 requires rustc 1.82
```