### PR TITLE
examples: reorganize Makefile

### DIFF
--- a/examples/acipher-rs/Makefile
+++ b/examples/acipher-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/acipher-rs/host/Makefile
+++ b/examples/acipher-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := acipher-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/acipher-rs/ta/Makefile
+++ b/examples/acipher-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/aes-rs/Makefile
+++ b/examples/aes-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/aes-rs/host/Makefile
+++ b/examples/aes-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := aes-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/aes-rs/ta/Makefile
+++ b/examples/aes-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/authentication-rs/Makefile
+++ b/examples/authentication-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/authentication-rs/host/Makefile
+++ b/examples/authentication-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := authentication-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/authentication-rs/ta/Makefile
+++ b/examples/authentication-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/big_int-rs/Makefile
+++ b/examples/big_int-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/big_int-rs/host/Makefile
+++ b/examples/big_int-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := big_int-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/big_int-rs/ta/Makefile
+++ b/examples/big_int-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/build_with_optee_utee_sys-rs/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/build_with_optee_utee_sys-rs/host/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := build_with_optee_utee_sys-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG) -vv
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/build_with_optee_utee_sys-rs/ta/Makefile
+++ b/examples/build_with_optee_utee_sys-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/no-std-ta.mk

--- a/examples/client_pool-rs/Makefile
+++ b/examples/client_pool-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/client_pool-rs/host/Makefile
+++ b/examples/client_pool-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := client_pool-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/client_pool-rs/ta/Makefile
+++ b/examples/client_pool-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/diffie_hellman-rs/Makefile
+++ b/examples/diffie_hellman-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/diffie_hellman-rs/host/Makefile
+++ b/examples/diffie_hellman-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := diffie_hellman-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/diffie_hellman-rs/ta/Makefile
+++ b/examples/diffie_hellman-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/digest-rs/Makefile
+++ b/examples/digest-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/digest-rs/host/Makefile
+++ b/examples/digest-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := digest-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/digest-rs/ta/Makefile
+++ b/examples/digest-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/error_handling-rs/Makefile
+++ b/examples/error_handling-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/error_handling-rs/host/Makefile
+++ b/examples/error_handling-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := error_handling-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/error_handling-rs/ta/Makefile
+++ b/examples/error_handling-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/hello_world-rs/Makefile
+++ b/examples/hello_world-rs/Makefile
@@ -15,37 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-
-
-.PHONY: all host ta clean emulate
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-emulate:
-	$(q)make -C host emulate TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-	$(q)make -C ta emulate TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/hello_world-rs/host/Makefile
+++ b/examples/hello_world-rs/host/Makefile
@@ -15,30 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := hello_world-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-.PHONY: all host strip clean emulate
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-emulate: all
-	@sync_to_emulator --host $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/hello_world-rs/ta/Makefile
+++ b/examples/hello_world-rs/ta/Makefile
@@ -15,43 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-emulate: all
-	@sync_to_emulator --ta $(OUT_DIR)/$(UUID).ta
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/hotp-rs/Makefile
+++ b/examples/hotp-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/hotp-rs/host/Makefile
+++ b/examples/hotp-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := hotp-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/hotp-rs/ta/Makefile
+++ b/examples/hotp-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/inter_ta-rs/Makefile
+++ b/examples/inter_ta-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/inter_ta-rs/host/Makefile
+++ b/examples/inter_ta-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := inter_ta-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/inter_ta-rs/ta/Makefile
+++ b/examples/inter_ta-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/message_passing_interface-rs/Makefile
+++ b/examples/message_passing_interface-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/message_passing_interface-rs/host/Makefile
+++ b/examples/message_passing_interface-rs/host/Makefile
@@ -15,27 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := message_passing_interface-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
-
+include ../../mk/host.mk

--- a/examples/message_passing_interface-rs/ta/Makefile
+++ b/examples/message_passing_interface-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-optee
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/std-ta.mk

--- a/examples/mk/common-ta.mk
+++ b/examples/mk/common-ta.mk
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Makefile for common TA (support building in std and no-std modes)
+
+# Default UUID location
+UUID ?= $(shell cat "../uuid.txt")
+# Default TA ELF name (before stripping and signing)
+TA_ELF_NAME ?= ta
+
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+OBJCOPY := $(CROSS_COMPILE)objcopy
+# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
+
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+# Set panic=abort for std and no-std
+RUSTFLAGS := -C panic=abort
+
+TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
+SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
+OUT_DIR ?= $(CURDIR)/target/$(TARGET)/release
+
+BUILDER ?= cargo
+FEATURES ?= 
+
+CLIPPY_OPTS := -D warnings \
+               -D clippy::unwrap_used \
+               -D clippy::expect_used \
+               -D clippy::panic
+
+all: clippy ta strip sign
+
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- $(CLIPPY_OPTS)
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
+
+strip: ta
+	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(TA_ELF_NAME) $(OUT_DIR)/stripped_${TA_ELF_NAME}
+
+sign: strip
+	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_${TA_ELF_NAME} --out $(OUT_DIR)/$(UUID).ta
+	@echo "SIGN =>  ${UUID}"
+
+emulate: all
+	@sync_to_emulator --ta $(OUT_DIR)/$(UUID).ta
+
+clean:
+	@cargo clean
+
+.PHONY: all clippy ta strip sign clean

--- a/examples/mk/example-root.mk
+++ b/examples/mk/example-root.mk
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Makefile in each example's root directory
+
+# ----------------------------------------------------------------------
+# Default configuration
+# ----------------------------------------------------------------------
+CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
+CROSS_COMPILE_TA   ?= aarch64-linux-gnu-
+TARGET_HOST        ?= aarch64-unknown-linux-gnu
+TARGET_TA          ?= aarch64-unknown-linux-gnu
+BUILDER            ?= cargo
+FEATURES           ?=
+
+# ----------------------------------------------------------------------
+# Default project layout (override as needed)
+# ----------------------------------------------------------------------
+HOST_DIRS ?= host
+TA_DIRS   ?= ta       # default: single TA at ./ta/
+
+.PHONY: all host ta clean emulate
+
+# ----------------------------------------------------------------------
+# Default build targets
+# ----------------------------------------------------------------------
+all: host ta
+
+host:
+	$(q)for d in $(HOST_DIRS); do \
+		make -C $$d \
+			TARGET=$(TARGET_HOST) \
+			CROSS_COMPILE=$(CROSS_COMPILE_HOST) || exit $$?; \
+	done
+
+ta:
+	$(q)for d in $(TA_DIRS); do \
+		make -C $$d TA_PATH=$$d \
+			TARGET=$(TARGET_TA) \
+			CROSS_COMPILE=$(CROSS_COMPILE_TA) \
+			BUILDER=$(BUILDER) \
+			FEATURES="$(FEATURES)" || exit $$?; \
+	done
+
+emulate:
+	$(q)for d in $(HOST_DIRS); do \
+		make -C $$d emulate TARGET=$(TARGET_HOST) \
+			CROSS_COMPILE=$(CROSS_COMPILE_HOST) || exit $$?; \
+	done
+	$(q)for d in $(TA_DIRS); do \
+		make -C $$d emulate TARGET=$(TARGET_TA) \
+			CROSS_COMPILE=$(CROSS_COMPILE_TA) \
+			BUILDER=$(BUILDER) \
+			FEATURES="$(FEATURES)" || exit $$?; \
+	done
+
+clean:
+	$(q)for d in $(HOST_DIRS); do \
+		make -C $$d clean || exit $$?; \
+	done
+	$(q)for d in $(TA_DIRS); do \
+		make -C $$d clean || exit $$?; \
+	done

--- a/examples/mk/host.mk
+++ b/examples/mk/host.mk
@@ -1,0 +1,61 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Makefile for all host (CA) applications and plugins
+
+# Use the package name from Cargo.toml for binary name
+OUT_DIR := $(CURDIR)/target/$(TARGET_HOST)/release
+OBJCOPY := $(CROSS_COMPILE_HOST)objcopy
+LINKER_CFG := target.$(TARGET_HOST).linker=\"$(CROSS_COMPILE_HOST)gcc\"
+
+# Binary name defined in Cargo.toml
+CARGO_BINARY_NAME := $(strip $(shell grep '^name *=' Cargo.toml | head -n1 | sed 's/.*= *"\([^"]*\)".*/\1/'))
+
+# Plugin specific variables (ignored if not a plugin)
+IS_PLUGIN ?= false
+PLUGIN_UUID ?= $(shell cat ../plugin_uuid.txt)
+
+CLIPPY_OPTS := -D warnings \
+               -D clippy::unwrap_used \
+               -D clippy::expect_used \
+               -D clippy::panic
+
+.PHONY: all clippy build post_build clean emulate
+
+all: clippy build post_build
+
+clippy:
+	@cargo fmt
+	@cargo clippy --target $(TARGET_HOST) -- $(CLIPPY_OPTS)
+
+build: clippy
+	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
+
+# Handle different post-build steps for plugins vs normal binaries
+post_build: build
+ifeq ($(IS_PLUGIN),true)
+	cp $(OUT_DIR)/lib$(CARGO_BINARY_NAME).so $(OUT_DIR)/$(PLUGIN_UUID).plugin.so
+else
+	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(CARGO_BINARY_NAME) $(OUT_DIR)/$(CARGO_BINARY_NAME).stripped.elf
+endif
+
+emulate: all
+	@sync_to_emulator --host $(OUT_DIR)/$(CARGO_BINARY_NAME)
+
+clean:
+	@cargo clean

--- a/examples/mk/no-std-ta.mk
+++ b/examples/mk/no-std-ta.mk
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Makefile for no-std TAs
+
+# Default UUID location
+UUID ?= $(shell cat "../uuid.txt")
+# Default TA ELF name (before stripping and signing)
+TA_ELF_NAME ?= ta
+
+TARGET ?= aarch64-unknown-linux-gnu
+CROSS_COMPILE ?= aarch64-linux-gnu-
+OBJCOPY := $(CROSS_COMPILE)objcopy
+# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
+# fix for the error: "unwinding panics are not supported without std" reported by clippy
+RUSTFLAGS := -C panic=abort
+EXTRA_FLAGS = -Z build-std=core,alloc -Z build-std-features=panic_immediate_abort
+
+TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
+SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
+OUT_DIR ?= $(CURDIR)/target/$(TARGET)/release
+
+CLIPPY_OPTS := -D warnings \
+               -D clippy::unwrap_used \
+               -D clippy::expect_used \
+               -D clippy::panic
+
+all: clippy ta strip sign
+
+clippy:
+	@cargo fmt
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) -- $(CLIPPY_OPTS)
+
+ta: clippy
+	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
+
+strip: ta
+	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(TA_ELF_NAME) $(OUT_DIR)/stripped_${TA_ELF_NAME}
+
+sign: strip
+	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_${TA_ELF_NAME} --out $(OUT_DIR)/$(UUID).ta
+	@echo "SIGN =>  ${UUID}"
+
+emulate: all
+	@sync_to_emulator --ta $(OUT_DIR)/$(UUID).ta
+
+clean:
+	@cargo clean
+
+.PHONY: all clippy ta strip sign clean

--- a/examples/mk/std-ta.mk
+++ b/examples/mk/std-ta.mk
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Makefile for std TAs
+
+# Default UUID location
+UUID ?= $(shell cat "../uuid.txt")
+# Default TA ELF name (before stripping and signing)
+TA_ELF_NAME ?= ta
+
+TARGET ?= aarch64-unknown-optee
+CROSS_COMPILE ?= aarch64-linux-gnu-
+OBJCOPY := $(CROSS_COMPILE)objcopy
+# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
+LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
+
+TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
+SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
+OUT_DIR ?= $(CURDIR)/target/$(TARGET)/release
+
+CLIPPY_OPTS := -D warnings \
+               -D clippy::unwrap_used \
+               -D clippy::expect_used \
+               -D clippy::panic
+
+all: clippy ta strip sign
+
+clippy:
+	@cargo fmt
+	@xargo clippy --target $(TARGET) -- $(CLIPPY_OPTS)
+
+ta: clippy
+	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
+
+strip: ta
+	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(TA_ELF_NAME) $(OUT_DIR)/stripped_${TA_ELF_NAME}
+
+sign: strip
+	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_${TA_ELF_NAME} --out $(OUT_DIR)/$(UUID).ta
+	@echo "SIGN =>  ${UUID}"
+
+emulate: all
+	@sync_to_emulator --ta $(OUT_DIR)/$(UUID).ta
+
+clean:
+	@cargo clean
+
+.PHONY: all clippy ta strip sign clean

--- a/examples/mnist-rs/Makefile
+++ b/examples/mnist-rs/Makefile
@@ -15,38 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
+TA_DIRS := ta/inference ta/train
 
-.PHONY: host ta all clean
-
-all: toolchain host ta
-
-toolchain:
-	rustup toolchain install
-
-host: toolchain
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta: toolchain
-	$(q)make -C ta/train TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-	$(q)make -C ta/inference TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	cd proto && cargo clean
-	$(q)make -C ta/train clean
-	$(q)make -C ta/inference clean
+include ../mk/example-root.mk

--- a/examples/mnist-rs/host/Makefile
+++ b/examples/mnist-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := mnist-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/mnist-rs/ta/inference/Makefile
+++ b/examples/mnist-rs/ta/inference/Makefile
@@ -15,37 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "./uuid.txt")
-NAME := inference
-
+UUID = $(shell cat "uuid.txt")
+TA_ELF_NAME = inference
 TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-RUSTFLAGS := -C panic=abort
-EXTRA_FLAGS = -Z build-std=core,alloc -Z build-std-features=panic_immediate_abort
+OUT_DIR ?= $(CURDIR)/../target/$(TARGET)/release
 
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/stripped_$(NAME)
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_$(NAME) --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../../mk/no-std-ta.mk

--- a/examples/mnist-rs/ta/train/Makefile
+++ b/examples/mnist-rs/ta/train/Makefile
@@ -15,37 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "./uuid.txt")
-NAME := train
-
+UUID = $(shell cat "uuid.txt")
+TA_ELF_NAME = train
 TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-RUSTFLAGS := -C panic=abort
-EXTRA_FLAGS = -Z build-std=core,alloc
+OUT_DIR ?= $(CURDIR)/../target/$(TARGET)/release
 
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/../target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo clippy --target $(TARGET) $(EXTRA_FLAGS) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TARGET) --release --config $(LINKER_CFG) $(EXTRA_FLAGS)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/stripped_$(NAME)
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_$(NAME) --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../../mk/no-std-ta.mk

--- a/examples/property-rs/Makefile
+++ b/examples/property-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/property-rs/host/Makefile
+++ b/examples/property-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := property-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/property-rs/ta/Makefile
+++ b/examples/property-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/random-rs/Makefile
+++ b/examples/random-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/random-rs/host/Makefile
+++ b/examples/random-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := random-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/random-rs/ta/Makefile
+++ b/examples/random-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/secure_db_abstraction-rs/Makefile
+++ b/examples/secure_db_abstraction-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/secure_db_abstraction-rs/host/Makefile
+++ b/examples/secure_db_abstraction-rs/host/Makefile
@@ -15,28 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-NAME := secure_db_abstraction-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/secure_db_abstraction-rs/ta/Makefile
+++ b/examples/secure_db_abstraction-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-optee
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/std-ta.mk

--- a/examples/secure_storage-rs/Makefile
+++ b/examples/secure_storage-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/secure_storage-rs/host/Makefile
+++ b/examples/secure_storage-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := secure_storage-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/secure_storage-rs/ta/Makefile
+++ b/examples/secure_storage-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/serde-rs/Makefile
+++ b/examples/serde-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/serde-rs/host/Makefile
+++ b/examples/serde-rs/host/Makefile
@@ -15,27 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := serde-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
-
+include ../../mk/host.mk

--- a/examples/serde-rs/ta/Makefile
+++ b/examples/serde-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-optee
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/std-ta.mk

--- a/examples/signature_verification-rs/Makefile
+++ b/examples/signature_verification-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/signature_verification-rs/host/Makefile
+++ b/examples/signature_verification-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := signature_verification-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/signature_verification-rs/ta/Makefile
+++ b/examples/signature_verification-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/supp_plugin-rs/Makefile
+++ b/examples/supp_plugin-rs/Makefile
@@ -15,34 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
+HOST_DIRS := host plugin
 
-.PHONY: host ta plugin all clean
-
-all: host ta plugin
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-plugin:
-	$(q)make -C plugin TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C plugin clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/supp_plugin-rs/host/Makefile
+++ b/examples/supp_plugin-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := supp_plugin-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/supp_plugin-rs/plugin/Makefile
+++ b/examples/supp_plugin-rs/plugin/Makefile
@@ -15,25 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := syslog_plugin
-PLUGIN_UUID := `cat ../plugin_uuid.txt`
+# Plugin specific configuration
+IS_PLUGIN := true
+PLUGIN_UUID := $(shell cat ../plugin_uuid.txt)
 
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET) --release --config $(LINKER_CFG)
-	cp $(CURDIR)/target/$(TARGET)/release/lib$(NAME).so $(CURDIR)/target/$(TARGET)/release/$(PLUGIN_UUID).plugin.so 
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/supp_plugin-rs/ta/Makefile
+++ b/examples/supp_plugin-rs/ta/Makefile
@@ -15,40 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../ta_uuid.txt")
+UUID = $(shell cat "../ta_uuid.txt")
 
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/tcp_client-rs/Makefile
+++ b/examples/tcp_client-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/tcp_client-rs/host/Makefile
+++ b/examples/tcp_client-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := tcp_client-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/tcp_client-rs/ta/Makefile
+++ b/examples/tcp_client-rs/ta/Makefile
@@ -17,40 +17,4 @@
 
 # STD-ONLY example
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/time-rs/Makefile
+++ b/examples/time-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/time-rs/host/Makefile
+++ b/examples/time-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := time-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/time-rs/ta/Makefile
+++ b/examples/time-rs/ta/Makefile
@@ -15,40 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk

--- a/examples/tls_client-rs/Makefile
+++ b/examples/tls_client-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/tls_client-rs/host/Makefile
+++ b/examples/tls_client-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := tls_client-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/tls_client-rs/ta/Makefile
+++ b/examples/tls_client-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-optee
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/std-ta.mk

--- a/examples/tls_server-rs/Makefile
+++ b/examples/tls_server-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/tls_server-rs/host/Makefile
+++ b/examples/tls_server-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := tls_server-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/tls_server-rs/ta/Makefile
+++ b/examples/tls_server-rs/ta/Makefile
@@ -15,35 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-optee
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@xargo clippy --target $(TARGET) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@xargo build --target $(TARGET) --release --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/std-ta.mk

--- a/examples/udp_socket-rs/Makefile
+++ b/examples/udp_socket-rs/Makefile
@@ -15,29 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# If _HOST or _TA specific compiler/target are not specified, then use common
-# compiler/target for both
-CROSS_COMPILE_HOST ?= aarch64-linux-gnu-
-CROSS_COMPILE_TA ?= aarch64-linux-gnu-
-TARGET_HOST ?= aarch64-unknown-linux-gnu
-TARGET_TA ?= aarch64-unknown-linux-gnu
-BUILDER ?= cargo
-FEATURES ?=
-
-.PHONY: host ta all clean
-
-all: host ta
-
-host:
-	$(q)make -C host TARGET=$(TARGET_HOST) \
-		CROSS_COMPILE=$(CROSS_COMPILE_HOST)
-
-ta:
-	$(q)make -C ta TARGET=$(TARGET_TA) \
-		CROSS_COMPILE=$(CROSS_COMPILE_TA) \
-		BUILDER=$(BUILDER) \
-		FEATURES="$(FEATURES)"
-
-clean:
-	$(q)make -C host clean
-	$(q)make -C ta clean
+include ../mk/example-root.mk

--- a/examples/udp_socket-rs/host/Makefile
+++ b/examples/udp_socket-rs/host/Makefile
@@ -15,26 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NAME := udp_socket-rs
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-all: clippy host strip
-
-clippy:
-	@cargo fmt
-	@cargo clippy --target $(TARGET_HOST) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-host: clippy
-	@cargo build --target $(TARGET_HOST) --release --config $(LINKER_CFG)
-
-strip: host
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/$(NAME) $(OUT_DIR)/$(NAME)
-
-clean:
-	@cargo clean
+include ../../mk/host.mk

--- a/examples/udp_socket-rs/ta/Makefile
+++ b/examples/udp_socket-rs/ta/Makefile
@@ -15,43 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# STD-ONLY example
-
-UUID ?= $(shell cat "../uuid.txt")
-
-TARGET ?= aarch64-unknown-linux-gnu
-CROSS_COMPILE ?= aarch64-linux-gnu-
-OBJCOPY := $(CROSS_COMPILE)objcopy
-# Configure the linker to use GCC, which works on both cross-compilation and ARM machines
-LINKER_CFG := target.$(TARGET).linker=\"$(CROSS_COMPILE)gcc\"
-
-# fix for the error: "unwinding panics are not supported without std" reported by clippy
-# Set panic=abort for std and no-std
-RUSTFLAGS := -C panic=abort
-
-TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
-SIGN := $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
-OUT_DIR := $(CURDIR)/target/$(TARGET)/release
-
-BUILDER ?= cargo
-FEATURES ?= 
-FEATURES ?=
-
-all: clippy ta strip sign
-
-clippy:
-	@cargo fmt
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) clippy --target $(TARGET) $(FEATURES) -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic
-
-ta: clippy
-	@RUSTFLAGS="$(RUSTFLAGS)" $(BUILDER) build --target $(TARGET) --release $(FEATURES) --config $(LINKER_CFG)
-
-strip: ta
-	@$(OBJCOPY) --strip-unneeded $(OUT_DIR)/ta $(OUT_DIR)/stripped_ta
-
-sign: strip
-	@$(SIGN) --uuid $(UUID) --key $(TA_SIGN_KEY) --in $(OUT_DIR)/stripped_ta --out $(OUT_DIR)/$(UUID).ta
-	@echo "SIGN =>  ${UUID}"
-
-clean:
-	@cargo clean
+include ../../mk/common-ta.mk


### PR DESCRIPTION
This PR reorganizes the **Makefiles** under `examples/`.

Currently, we have **26 examples** (and more in the future). Updating each example's Makefile individually makes maintenance and review difficult. Since most Makefile logic is shared, this PR centralizes common definitions under `examples/mk/`:

* `examples-root.mk`
* `host.mk` — for CAs and plugins
* `common-ta.mk`
* `std-ta.mk`
* `no-std-ta.mk`


The Makefiles design is suitable for this directory layout of each example:

```
example/
├── host/
│   ├── host1/
│   │   └── Makefile    # includes host.mk
│   └── host2/
│       └── Makefile
├── plugin/              # example with one plugin app, can be multiple apps like in the host/
│   ├── src/
│   └── Makefile         # includes host.mk
├── ta/
│   ├── ta1/
│   │   └── Makefile     # includes common-ta.mk or std-ta.mk or no-std-ta.mk
│   └── ta2/
│       └── Makefile
├── Makefile              # includes examples-root.mk
└── uuid.txt              # TA UUID
```

Our all examples are fit for this structure: Most of examples have one host and one TA; 
Some examples (e.g., `supp_plugin-rs`, `mnist-rs`) override certain variables (such as location of `uuid.txt`) to fit specific needs. The Makefile variables are designed to be easily overridden for such cases.

Please pay special attention when reviewing the `examples/mk/*`, `supp_plugin-rs` and `mnist-rs`.

#### Future Work

This is the first step in cleaning up and unifying our Makefile structure.
With this reorganization, future Makefile updates can be made more consistently and reviewed more easily.

In the dev docker environment, the `examples/mk` path can be written as a constant include path used by each separate examples.