### PR TITLE
Improve error messages on missing environment during build

### DIFF
--- a/optee-teec/optee-teec-sys/build.rs
+++ b/optee-teec/optee-teec-sys/build.rs
@@ -46,7 +46,7 @@ fn link() {
     let library_path = PathBuf::from(optee_client_dir).join("usr/lib");
     if !library_path.exists() {
         panic!(
-            "Library path {} does not exist",
+            "OPTEE_CLIENT_EXPORT usr/lib path {} does not exist",
             library_path.display()
         );
     }

--- a/optee-utee/optee-utee-sys/build.rs
+++ b/optee-utee/optee-utee-sys/build.rs
@@ -38,11 +38,11 @@ fn is_feature_enable(feature: &str) -> Result<bool, VarError> {
 }
 
 fn link() {
-    let optee_os_dir = env::var("TA_DEV_KIT_DIR").expect("TA_DEV_KIT_DIR not set");
-    let library_path = PathBuf::from(optee_os_dir).join("lib");
+    let ta_dev_kit_dir = env::var("TA_DEV_KIT_DIR").expect("TA_DEV_KIT_DIR not set");
+    let library_path = PathBuf::from(ta_dev_kit_dir).join("lib");
     if !library_path.exists() {
         panic!(
-            "Library path {} does not exist",
+            "TA_DEV_KIT_DIR lib path {} does not exist",
             library_path.display()
         );
     }

--- a/optee-utee/systest/build.rs
+++ b/optee-utee/systest/build.rs
@@ -23,11 +23,11 @@ use std::path::PathBuf;
 fn main() {
     let mut cfg = ctest::TestGenerator::new();
     let ta_include_path = {
-        let optee_os_dir = env::var("TA_DEV_KIT_DIR").expect("TA_DEV_KIT_DIR not set");
-        let include_path = PathBuf::from(optee_os_dir).join("include");
+        let ta_dev_kit_dir = env::var("TA_DEV_KIT_DIR").expect("TA_DEV_KIT_DIR not set");
+        let include_path = PathBuf::from(ta_dev_kit_dir).join("include");
         if !include_path.exists() {
             panic!(
-                "TA DevKit include path {} does not exist",
+                "TA_DEV_KIT_DIR include path {} does not exist",
                 include_path.display()
             );
         }


### PR DESCRIPTION
Several build.rs files fail with a panic when the environment variables are not present. It's nicer for users when a more informative message is provides. 

To help the user find issues early also check if the expected directories are available at the location indicated by the environment variables.