### PR TITLE
ci/build_qemu_image: free disk space

### DIFF
--- a/.github/workflows/reuse_build_test_qemu_image.yml
+++ b/.github/workflows/reuse_build_test_qemu_image.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install OP-TEE dependencies
         run: |
-          ./setup_optee_dependencies.sh
+          sudo ./setup_optee_dependencies.sh
           
       - name: Checkout OP-TEE repository
         run: |


### PR DESCRIPTION
This job runs on the host (not in a container), which allows us to clean up unused packages on the host machine.
Note that sudo is required for apt-get operations.
The cleanup workflow code is copied from the other ci: https://github.com/apache/teaclave-trustzone-sdk/blob/main/.github/workflows/reuse_test_in_optee_repo.yml#L38

Verified successful in my repo:
https://github.com/DemesneGH/rust-optee-trustzone-sdk/actions/runs/18872824474

I’ll squash the commits when merging.


