### PR TITLE
dev_docker: move OP-TEE version from image name to tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   test-nostd-build-on-dev-docker:
     runs-on: ubuntu-latest
     container: 
-      image: teaclave/teaclave-trustzone-emulator-nostd-optee-4.7.0-expand-memory:latest
+      image: teaclave/teaclave-trustzone-emulator-nostd-expand-memory:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
   test-std-build-on-dev-docker:
     runs-on: ubuntu-latest
     container:
-      image: teaclave/teaclave-trustzone-emulator-std-optee-4.7.0-expand-memory:latest
+      image: teaclave/teaclave-trustzone-emulator-std-expand-memory:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/emulate-and-dev-in-docker-std.md
+++ b/docs/emulate-and-dev-in-docker-std.md
@@ -24,14 +24,14 @@ The **dev-env with std support** enables **developing TA using Rust std** by pro
 ### Pull the Docker Image
 ```bash
 # Pull the dev-env with std support for developing TA using Rust std
-$ docker pull teaclave/teaclave-trustzone-emulator-std-optee-4.5.0-expand-memory:latest
+$ docker pull teaclave/teaclave-trustzone-emulator-std-expand-memory:latest
 
 # Launch the dev-env container
 $ docker run -it --rm \
   --name teaclave_dev_env \
   -v $(pwd):/root/teaclave_sdk_src \
   -w /root/teaclave_sdk_src \
-  teaclave/teaclave-trustzone-emulator-std-optee-4.5.0-expand-memory:latest
+  teaclave/teaclave-trustzone-emulator-std-expand-memory:latest
 ```
 
 ### One-Time Setup Inside Container

--- a/docs/emulate-and-dev-in-docker.md
+++ b/docs/emulate-and-dev-in-docker.md
@@ -17,7 +17,7 @@ both the Normal World and Secure World environments.
 **Terminal A** (Main development terminal):
 ```bash
 # Pull the pre-built development environment
-$ docker pull teaclave/teaclave-trustzone-emulator-nostd-optee-4.5.0-expand-memory:latest
+$ docker pull teaclave/teaclave-trustzone-emulator-nostd-expand-memory:latest
 
 # Clone the repository
 $ git clone https://github.com/apache/teaclave-trustzone-sdk.git && \
@@ -28,7 +28,7 @@ $ docker run -it --rm \
   --name teaclave_dev_env \
   -v $(pwd):/root/teaclave_sdk_src \
   -w /root/teaclave_sdk_src \
-  teaclave/teaclave-trustzone-emulator-nostd-optee-4.5.0-expand-memory:latest
+  teaclave/teaclave-trustzone-emulator-nostd-expand-memory:latest
 ```
 
 ## 2. Build the Hello World Example

--- a/docs/operation-guide-for-integration-with-each-optee-release.md
+++ b/docs/operation-guide-for-integration-with-each-optee-release.md
@@ -100,15 +100,3 @@ After step 3 PR is merged, rebuild the development Docker image.
    
    This operation requires access to the Teaclave Docker Hub organization. Please 
    contact project maintainers for assistance.
-
-### 5. Update CI Configuration for Development Docker
-
-Following the Docker image publication, update the CI workflow to reference the new 
-OP-TEE version.
-
-**Configuration Location:** 
-https://github.com/apache/teaclave-trustzone-sdk/blob/main/.github/workflows/ci.yml#L72
-
-**Affected Jobs:**
-- `test-nostd-build-on-dev-docker`
-- `test-std-build-on-dev-docker`

--- a/docs/release-tips.md
+++ b/docs/release-tips.md
@@ -104,7 +104,7 @@ $ cd apache-teaclave-trustzone-sdk-$VERSION
 $ docker run -it --rm \
   -v $(pwd):/root/teaclave_sdk_src \
   -w /root/teaclave_sdk_src \
-  teaclave/teaclave-trustzone-emulator-nostd-optee-$OPTEE_VERSION-expand-memory:latest
+  teaclave/teaclave-trustzone-emulator-nostd-expand-memory:optee-$OPTEE_VERSION
 # Inside the docker container:
 root@xxxx:~/teaclave_sdk_src# make
 ```

--- a/scripts/release/build_dev_docker.sh
+++ b/scripts/release/build_dev_docker.sh
@@ -38,15 +38,23 @@ docker build \
   -f "$DOCKERFILE" \
   --build-arg OPTEE_VERSION="$OPTEE_VER" \
   --target no-std-build-env \
-  -t teaclave/teaclave-trustzone-emulator-nostd-optee-${OPTEE_VER}-expand-memory:latest \
+  -t teaclave/teaclave-trustzone-emulator-nostd-expand-memory:optee-${OPTEE_VER} \
+  -t teaclave/teaclave-trustzone-emulator-nostd-expand-memory:latest \
   .
 
 # Build std Docker image
 docker build \
   -f "$DOCKERFILE" \
   --build-arg OPTEE_VERSION="$OPTEE_VER" \
-  -t teaclave/teaclave-trustzone-emulator-std-optee-${OPTEE_VER}-expand-memory:latest \
+  -t teaclave/teaclave-trustzone-emulator-std-expand-memory:optee-${OPTEE_VER} \
+  -t teaclave/teaclave-trustzone-emulator-std-expand-memory:latest \
   .
 
 echo "Docker images built successfully!"
+echo ""
+echo "To push the images to Docker Hub, run:"
+echo "docker push teaclave/teaclave-trustzone-emulator-nostd-expand-memory:optee-${OPTEE_VER}"
+echo "docker push teaclave/teaclave-trustzone-emulator-nostd-expand-memory:latest"
+echo "docker push teaclave/teaclave-trustzone-emulator-std-expand-memory:optee-${OPTEE_VER}"
+echo "docker push teaclave/teaclave-trustzone-emulator-std-expand-memory:latest"
 


### PR DESCRIPTION
Removing the OP-TEE version from the image name improves maintainability for CI and docs.

related: 
https://github.com/apache/teaclave-trustzone-sdk/pull/248#discussion_r2471688385
https://github.com/apache/teaclave-trustzone-sdk/issues/249