### PR TITLE
add the FEATURES for no-std config file and correct Dockerfile link

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -54,7 +54,7 @@ Prerequisites](https://optee.readthedocs.io/en/latest/building/prerequisites.htm
    ```
 
    Alternatively, you can use a docker container built with our
-   [Dockerfile](Dockerfile).
+   [Dockerfile](../Dockerfile).
 
 2. After installing dependencies or building the Docker image, fetch the source
    code from the official GitHub repository:

--- a/scripts/runtime/config/ta/no-std/aarch64
+++ b/scripts/runtime/config/ta/no-std/aarch64
@@ -21,3 +21,5 @@ export CROSS_COMPILE_TA="aarch64-linux-gnu-"
 
 # sdk example using this env to distinguish between xargo and cargo
 export BUILDER="cargo"
+# Initialize FEATURES as empty for no-std TAs
+export FEATURES=""

--- a/scripts/runtime/config/ta/no-std/arm32
+++ b/scripts/runtime/config/ta/no-std/arm32
@@ -21,3 +21,5 @@ export CROSS_COMPILE_TA="arm-linux-gnueabihf-"
 
 # sdk example using this env to distinguish between xargo and cargo
 export BUILDER="cargo"
+# Initialize FEATURES as empty for no-std TAs
+export FEATURES=""


### PR DESCRIPTION
# Overview

I found an issue in the latest `std` environment image.
When switching from `std` mode `to no-std` mode, the `FEATURES` environment variable is not reset properly.

## Details

Here’s an example of the problem:

```bash
Setting up bash profile environment...
Loading OP-TEE environment configuration...
No active Host configuration found, setting default to aarch64
Creating QEMU shared directory: /opt/teaclave/shared
=== OP-TEE Environment Configuration ===
TA:   std/aarch64
Host: aarch64

TA Configuration:
  TARGET_TA: aarch64-unknown-optee
  CROSS_COMPILE_TA: aarch64-linux-gnu-
  TA_DEV_KIT_DIR: /opt/teaclave/optee/optee_os/out/arm-plat-vexpress/export-ta_arm64

Host Configuration:
  TARGET_HOST: aarch64-unknown-linux-gnu
  CROSS_COMPILE_HOST: aarch64-linux-gnu-
  OPTEE_CLIENT_EXPORT: /opt/teaclave/optee/optee_client/export_arm64

QEMU Shared Directory: /opt/teaclave/shared
root@c2db8532169b:~/teaclave_sdk_src# echo $BUILDER
xargo
root@c2db8532169b:~/teaclave_sdk_src# echo $FEATURES
--features std
root@c2db8532169b:~/teaclave_sdk_src# switch_config --ta no-std/aarch64
Switching ta to: no-std/aarch64

=== Current Active Configuration ===
TA:   no-std/aarch64
Host: aarch64

Reloading environment in current shell...
Loading OP-TEE environment configuration...
QEMU shared directory already exists: /opt/teaclave/shared
=== OP-TEE Environment Configuration ===
TA:   no-std/aarch64
Host: aarch64

TA Configuration:
  TARGET_TA: aarch64-unknown-linux-gnu
  CROSS_COMPILE_TA: aarch64-linux-gnu-
  TA_DEV_KIT_DIR: /opt/teaclave/optee/optee_os/out/arm-plat-vexpress/export-ta_arm64

Host Configuration:
  TARGET_HOST: aarch64-unknown-linux-gnu
  CROSS_COMPILE_HOST: aarch64-linux-gnu-
  OPTEE_CLIENT_EXPORT: /opt/teaclave/optee/optee_client/export_arm64

QEMU Shared Directory: /opt/teaclave/shared
✅ Configuration applied to current shell!
root@c2db8532169b:~/teaclave_sdk_src# echo $BUILDER
cargo
root@c2db8532169b:~/teaclave_sdk_src# echo $FEATURES
--features std
```

After investigation, I found that both configuration files under
`scripts/runtime/config/ta/no-std/` (`aarch64` and `arm32`) https://github.com/apache/teaclave-trustzone-sdk/tree/54c8b7125f4a04b6de28f7c40c4dcd9e2c327659/scripts/runtime/config/ta/no-std were missing the initialization of the `FEATURES` variable.

## fix

I added the following lines to both files to explicitly reset `FEATURES` in `no-std` environments:

```bash
# Initialize FEATURES as empty for no-std TAs
export FEATURES=""
```
# Additional Minor Fix

I also corrected a small documentation link in [docs/advanced-setup.md](https://github.com/apache/teaclave-trustzone-sdk/blob/54c8b7125f4a04b6de28f7c40c4dcd9e2c327659/docs/advanced-setup.md) (`Dockerfile path`),
which didn’t affect functionality but was slightly incorrect.


