### PR TITLE
examples: change for acipher-rs

### DIFF
--- a/examples/acipher-rs/proto/src/lib.rs
+++ b/examples/acipher-rs/proto/src/lib.rs
@@ -22,9 +22,9 @@ use num_enum::{FromPrimitive, IntoPrimitive};
 #[repr(u32)]
 pub enum Command {
     GenKey,
-    GetSize,
     Encrypt,
     Decrypt,
+    GetSize,
     #[default]
     Unknown,
 }

--- a/examples/acipher-rs/ta/src/main.rs
+++ b/examples/acipher-rs/ta/src/main.rs
@@ -97,8 +97,13 @@ fn encrypt(rsa: &mut RsaCipher, params: &mut Parameters) -> Result<()> {
             match cipher.encrypt(&[], plain_text) {
                 Err(e) => Err(e),
                 Ok(cipher_text) => {
-                    p1.buffer().clone_from_slice(&cipher_text);
-                    Ok(())
+                    if cipher_text.len() > p1.buffer().len() {
+                        p1.set_updated_size(cipher_text.len());
+                        Err(ErrorKind::ShortBuffer.into())
+                    } else {
+                        p1.buffer().clone_from_slice(&cipher_text);
+                        Ok(())
+                    }
                 }
             }
         }


### PR DESCRIPTION
fix potential buffer overflow and match behavior with optee_examples