### PR TITLE
chore: get rid of now-stabilized error_in_core feature

### DIFF
--- a/optee-utee/src/lib.rs
+++ b/optee-utee/src/lib.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(error_in_core))]
 
 // Requires `alloc`.
 #[macro_use]


### PR DESCRIPTION
Attempting to build the SDK without stable compiler features is not possible right now due to the use of `#![feature(error_in_core)]`. However, this feature was [stabilized in rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/#what-s-in-1-81-0-stable) in September 2024.

It would be good to remove the now-unneeded unstable flag.