### PR TITLE
optee-teec: API improvements and dependency cleanup

### DIFF
--- a/crates/optee-teec/src/parameter.rs
+++ b/crates/optee-teec/src/parameter.rs
@@ -127,6 +127,26 @@ impl<'a> ParamTmpRef<'a> {
         }
     }
 
+    /// Creates a temporary input/output memory reference.
+    ///
+    /// `buffer` is a region of memory which needs to be temporarily
+    /// registered for the duration of the `Operation` and can be both
+    /// read and written by the Trusted Application (TA).
+    ///
+    /// This is useful when you need to pass data to a TA that will
+    /// modify it and return the modified data in the same buffer.
+    pub fn new_inout(buffer: &'a mut [u8]) -> Self {
+        let raw = raw::TEEC_TempMemoryReference {
+            buffer: buffer.as_ptr() as _,
+            size: buffer.len(),
+        };
+        Self {
+            raw,
+            param_type: ParamType::MemrefTempInout,
+            _marker: marker::PhantomData,
+        }
+    }
+
     pub fn updated_size(&self) -> usize {
         self.raw.size
     }


### PR DESCRIPTION
This PR enhances the optee-teec parameter API and cleans up unused dependencies.

## Changes

### Add bidirectional memory reference support
Adds `ParamTmpRef::new_inout()` to create temporary memory references with bidirectional data flow. This completes the memory reference API alongside the existing `new_input()` and `new_out
put()` methods, corresponding to `TEEC_MEMREF_TEMP_INOUT` in the GlobalPlatform TEE Client API specification.

**Use case:** Operations where the TA needs to read initial data, process it, and write results back to the same buffer (e.g., encryption/decryption).

### Remove unused optee-teec-macros dependency
The `optee-teec-macros` crate was a dependency but its exports (`plugin_init`, `plugin_invoke`) are not used by the core TEEC client API. Removing it simplifies the dependency tree and redu
ces build time.

## Testing
- Build verification passed
- No breaking changes to existing API