### PR TITLE
optee-utee: correct return type in property for binary version

### DIFF
--- a/crates/optee-utee/src/property.rs
+++ b/crates/optee-utee/src/property.rs
@@ -436,7 +436,7 @@ define_property_key!(
     TeeTrustedOsImplementationBinaryVersion,
     TeeImplementation,
     "gpd.tee.trustedos.implementation.binaryversion",
-    Vec<u8>
+    u32
 );
 define_property_key!(
     TeeTrustedOsManufacturer,
@@ -454,7 +454,7 @@ define_property_key!(
     TeeFirmwareImplementationBinaryVersion,
     TeeImplementation,
     "gpd.tee.firmware.implementation.binaryversion",
-    Vec<u8>
+    u32
 );
 define_property_key!(
     TeeFirmwareManufacturer,


### PR DESCRIPTION
In optee, the type defined for
"gpd.tee.trustedos.implementation.binaryversion" and "gpd.tee.firmware.implementation.binaryversion"
is USER_TA_PROP_TYPE_U32